### PR TITLE
Make contributions easier

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+tasks:
+    - before: nvm install 10 && nvm use 10
+      init: npm install
+      command: npm run start
+ports:
+    - port: 8080
+      onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Trilium Notes
 
 [![Join the chat at https://gitter.im/trilium-notes/Lobby](https://badges.gitter.im/trilium-notes/Lobby.svg)](https://gitter.im/trilium-notes/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-Trilium Notes is a hierarchical note taking application with focus on building large personal knowledge bases. See [screenshots](https://github.com/zadam/trilium/wiki/Screenshot-tour) for quick overview: 
+Trilium Notes is a hierarchical note taking application with focus on building large personal knowledge bases. See [screenshots](https://github.com/zadam/trilium/wiki/Screenshot-tour) for quick overview:
 
 ![](https://raw.githubusercontent.com/wiki/zadam/trilium/images/screenshot.png)
 
@@ -35,3 +35,15 @@ Trilium is provided as either desktop application (Linux, Windows, Mac) or web a
 [See wiki for complete list of documentation pages.](https://github.com/zadam/trilium/wiki/)
 
 You can also read [Patterns of personal knowledge base](https://github.com/zadam/trilium/wiki/Patterns-of-personal-knowledge-base) to get some inspiration on how you might use Trilium.
+
+## Contribute
+
+Use a browser based dev environment
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/zadam/trilium)
+
+Or clone locally and run
+```
+npm install
+npm run start
+```


### PR DESCRIPTION
This PR allows contributors and others to give the trilium code base a spin without going local by using Gitpod, a free dev environment service. I added a contribute section to the bottom of the readme, which includes a button that will start, build (npm install) and run the browser app. Gitpod.io supports integrated code reviews and node debugging, too.

Here is what it looks like:

<img width="2031" alt="screenshot 2019-01-07 at 13 49 03" src="https://user-images.githubusercontent.com/372735/50769454-48ed3900-1284-11e9-8c61-025850ee4578.png">

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/a4590905-643b-4f25-b181-dd606e8f5deb)
