### PR TITLE
use electron-builder for dev install

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "start-electron": "electron . --disable-gpu",
     "build-backend-docs": "jsdoc -c jsdoc-conf.json -d ./docs/backend_api src/entities/*.js src/services/backend_script_api.js",
     "build-frontend-docs": "jsdoc -c jsdoc-conf.json -d ./docs/frontend_api src/public/javascripts/entities/*.js src/public/javascripts/services/frontend_script_api.js",
-    "build-docs": "npm run build-backend-docs && npm run build-frontend-docs"
+    "build-docs": "npm run build-backend-docs && npm run build-frontend-docs",
+    "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {
     "async-mutex": "0.1.3",
@@ -67,6 +68,7 @@
   "devDependencies": {
     "devtron": "1.4.0",
     "electron": "4.0.1",
+    "electron-builder": "20.38.4",
     "electron-compile": "6.4.3",
     "electron-packager": "13.0.1",
     "electron-rebuild": "1.8.2",


### PR DESCRIPTION
This will build deps as required for electron as well as the os.

This fixes the missing binding error for sqlite3 when trying to run the
electron app after a fresh npm i