### PR TITLE
Querying by dateCreated and dateModified virtual attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2093,6 +2093,11 @@
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
       "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
     },
+    "dayjs": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.6.tgz",
+      "integrity": "sha512-NLhaSS1/wWLRFy0Kn/VmsAExqll2zxRUPmPbqJoeMKQrFxG+RT94VMSE+cVljB6A76/zZkR0Xub4ihTHQ5HgGg=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "cls-hooked": "4.2.2",
     "commonmark": "0.28.1",
     "cookie-parser": "1.4.4",
+    "dayjs": "^1.8.5",
     "debug": "4.1.1",
     "ejs": "2.6.1",
     "electron-debug": "2.1.0",

--- a/src/services/parse_filters.js
+++ b/src/services/parse_filters.js
@@ -1,8 +1,30 @@
+const dayjs = require("dayjs");
+
+const labelRegex = /(\b(and|or)\s+)?@(!?)([\w_-]+|"[^"]+")((=|!=|<|<=|>|>=)([\w_-]+|"[^"]+"))?/i;
+const smartValueRegex = /^(TODAY|NOW)((\+|\-)(\d+)(H|D|M|Y)){0,1}$/i;
+
+function calculateSmartValue(v) {
+    const normalizedV = v.toUpperCase() + "+0D"; // defaults of sorts
+    const [ , keyword, sign, snum, unit] = /(TODAY|NOW)(\+|\-)(\d+)(H|D|M|Y)/.exec(normalizedV);
+    const num = parseInt(snum);
+
+    if (keyword != "TODAY" && keyword != "NOW") {
+        return v;
+    }
+
+    const fullUnit = {
+        TODAY: { D: "days", M: "months", Y: "years" },
+        NOW: { D: "days", M: "minutes", H: "hours" }
+    }[keyword][unit];
+
+    const format = keyword == "TODAY" ? "YYYY-MM-DD" : "YYYY-MM-DDTHH:mm";
+    const date = (sign == "+" ? dayjs().add(num, fullUnit) : dayjs().subtract(num, fullUnit));
+
+    return date.format(format);
+}
+
 module.exports = function(searchText) {
     const labelFilters = [];
-
-    const labelRegex = /(\b(and|or)\s+)?@(!?)([\w_-]+|"[^"]+")((=|!=|<|<=|>|>=)([\w_-]+|"[^"]+"))?/i;
-
     let match = labelRegex.exec(searchText);
 
     function trimQuotes(str) { return str.startsWith('"') ? str.substr(1, str.length - 2) : str; }
@@ -11,11 +33,17 @@ module.exports = function(searchText) {
         const relation = match[2] !== undefined ? match[2].toLowerCase() : 'and';
         const operator = match[3] === '!' ? 'not-exists' : 'exists';
 
+        const value = match[7] !== undefined ? trimQuotes(match[7]) : null
+
         labelFilters.push({
             relation: relation,
             name: trimQuotes(match[4]),
             operator: match[6] !== undefined ? match[6] : operator,
-            value: match[7] !== undefined ? trimQuotes(match[7]) : null
+            value: (
+                value && value.match(smartValueRegex)
+                    ? calculateSmartValue(value)
+                    : value
+            )
         });
 
         // remove labels from further fulltext search
@@ -24,5 +52,5 @@ module.exports = function(searchText) {
         match = labelRegex.exec(searchText);
     }
 
-    return {labelFilters: labelFilters, searchText};
+    return { labelFilters: labelFilters, searchText };
 };


### PR DESCRIPTION
A first, not very smart implementation of two virtual attributes for search queries: dateModified and dateCreated.

Also, smart searches, like @dateModified>=TODAY-1d.

See https://github.com/zadam/trilium/issues/38