### PR TITLE
Add Ctrl+Shift+L to pre-select "add to note"

### DIFF
--- a/src/public/javascripts/dialogs/add_link.js
+++ b/src/public/javascripts/dialogs/add_link.js
@@ -24,7 +24,11 @@ function setLinkType(linkType) {
     linkTypeChanged();
 }
 
-async function showDialog() {
+async function showDialogForClone() {
+    showDialog('selected-to-current');
+}
+
+async function showDialog(linkType) {
     glob.activeDialog = $dialog;
 
     if (noteDetailService.getActiveNoteType() === 'text') {
@@ -36,6 +40,10 @@ async function showDialog() {
         $linkTypeHtml.prop('disabled', true);
 
         setLinkType('selected-to-current');
+    }
+
+    if (linkType==='selected-to-current') {
+        setLinkType(linkType);
     }
 
     $dialog.modal();
@@ -142,5 +150,6 @@ $linkTypes.change(linkTypeChanged);
 $dialog.on("hidden.bs.modal", () => noteDetailText.focus());
 
 export default {
-    showDialog
+    showDialog,
+    showDialogForClone
 };

--- a/src/public/javascripts/services/entrypoints.js
+++ b/src/public/javascripts/services/entrypoints.js
@@ -23,6 +23,7 @@ function registerEntrypoints() {
     jQuery.hotkeys.options.filterTextInputs = false;
 
     utils.bindShortcut('ctrl+l', addLinkDialog.showDialog);
+    utils.bindShortcut('ctrl+shift+l', addLinkDialog.showDialogForClone);
 
     $("#jump-to-note-dialog-button").click(jumpToNoteDialog.showDialog);
     utils.bindShortcut('ctrl+j', jumpToNoteDialog.showDialog);


### PR DESCRIPTION
Allow using Ctrl-Shift-L to clone a note as a child without first needing to select the radio-button.