### PR TITLE
Exit on SIGINT

### DIFF
--- a/src/www
+++ b/src/www
@@ -8,6 +8,11 @@ process.on('unhandledRejection', error => {
     require('./services/log').info(error);
 });
 
+process.on('SIGINT', function() {
+	console.log("Caught interrupt signal. Exiting.");
+	process.exit();
+});
+
 const { app, sessionParser } = require('./app');
 const debug = require('debug')('node:server');
 const fs = require('fs');


### PR DESCRIPTION
Pressing Ctrl+C used to not exit the application (at least when running the Docker image).

Explicitly catching the `SIGINT` interrupt signal and exiting fixes the problem.

We currently make it exit immediately as soon as the signal arrives.

In the future, it may be preferable to do dispatch some event and try to exit more gracefully (finish any ongoing synchronization work, etc.)
Still, I think it's better to exit directly than to not do anything at all, in which case `SIGKILL` is likely to follow and kill the process even more abruptly.