### PR TITLE
Add host option

### DIFF
--- a/config-sample.ini
+++ b/config-sample.ini
@@ -3,6 +3,8 @@
 instanceName=
 
 [Network]
+# host setting is relevant only for web deployments - set the host on which the server will listen
+# host=0.0.0.0
 # port setting is relevant only for web deployments, desktop builds run on random free port
 port=8080
 # true for TLS/SSL/HTTPS (secure), false for HTTP (unsecure).

--- a/src/services/host.js
+++ b/src/services/host.js
@@ -1,0 +1,10 @@
+const config = require('./config');
+const env = require('./env');
+
+let environmentHost;
+
+if (process.env.TRILIUM_HOST) {
+    environmentHost = process.env.TRILIUM_HOST;
+}
+
+module.exports = Promise.resolve(environmentHost || config['Network']['host'] || '0.0.0.0');

--- a/src/www
+++ b/src/www
@@ -25,6 +25,7 @@ const messagingService = require('./services/messaging');
 const utils = require('./services/utils');
 const sqlInit = require('./services/sql_init');
 const port = require('./services/port');
+const host = require('./services/host');
 const semver = require('semver');
 
 if (!semver.satisfies(process.version, ">=10.5.0")) {
@@ -36,8 +37,10 @@ let httpServer;
 
 async function startTrilium() {
     const usedPort = await port;
+    const usedHost = await host;
 
     app.set('port', usedPort);
+    app.set('host', usedHost);
 
     if (config['Network']['https']) {
         if (!config['Network']['keyPath'] || !config['Network']['keyPath'].trim().length) {
@@ -70,7 +73,7 @@ async function startTrilium() {
      */
 
     httpServer.keepAliveTimeout = 120000 * 5;
-    httpServer.listen(usedPort);
+    httpServer.listen(usedPort, usedHost);
     httpServer.on('error', onError);
     httpServer.on('listening', () => debug('Listening on port' + httpServer.address().port));
 


### PR DESCRIPTION
Add an option for the server to listen to on a specific IP. This is useful to limit the server to listening only on localhost.