### PR TITLE
Shebang fix

### DIFF
--- a/bin/build-server.sh
+++ b/bin/build-server.sh
@@ -30,7 +30,7 @@ rm -r ./node_modules/sqlite3/lib/binding/*
 
 cp -r ../../bin/deps/linux-x64/sqlite/node* ./node_modules/sqlite3/lib/binding/
 
-printf "#/bin/sh\n./node/bin/node src/www" > trilium.sh
+printf "#!/bin/sh\n./node/bin/node src/www" > trilium.sh
 chmod 755 trilium.sh
 
 cd ..


### PR DESCRIPTION
Because of this typo, systemd unit can't start and gives this error:
```log
Jul 12 06:14:44 domain systemd[1]: Started Trilium.
Jul 12 06:14:44 domain systemd[28275]: trilium.service: Failed to execute command: Exec format error
Jul 12 06:14:44 domain systemd[28275]: trilium.service: Failed at step EXEC spawning /home/trilium/trilium-linux-x64-server/trilium.sh: Exec format error
Jul 12 06:14:44 domain systemd[1]: trilium.service: Main process exited, code=exited, status=203/EXEC
Jul 12 06:14:44 domain systemd[1]: trilium.service: Failed with result 'exit-code'.
```