### PR TITLE
Import: use upload mime type if mime cannot be detected from filename

### DIFF
--- a/src/services/import/single.js
+++ b/src/services/import/single.js
@@ -42,12 +42,13 @@ async function importImage(file, parentNote, importContext) {
 async function importFile(importContext, file, parentNote) {
     const originalName = file.originalname;
     const size = file.size;
+    const mime = mimeService.getMime(originalName);
 
     const {note} = await noteService.createNote(parentNote.noteId, originalName, file.buffer, {
         target: 'into',
         isProtected: parentNote.isProtected && protectedSessionService.isProtectedSessionAvailable(),
         type: 'file',
-        mime: mimeService.getMime(originalName),
+        mime: mime === false ? file.mimetype : mime,
         attributes: [
             { type: "label", name: "originalFileName", value: originalName },
             { type: "label", name: "fileSize", value: size }


### PR DESCRIPTION
For some files (such as Keepass databases), mime-db doesn't know about the unofficial mime type (application/x-keepass2) used. I'll create a PR at mime-db to add that mime type if I can find a good source.