### PR TITLE
Fix typo in note export screen.

### DIFF
--- a/src/views/dialogs/export.ejs
+++ b/src/views/dialogs/export.ejs
@@ -22,7 +22,7 @@
                         <div class="form-check">
                             <input class="form-check-input" type="radio" name="export-subtree-format" id="export-subtree-format-html"
                                    value="html">
-                            <label class="form-check-label" for="export-subtree-format-html">HTML in TAR archiv - this is recommended since this preserves all the formatting.</label>
+                            <label class="form-check-label" for="export-subtree-format-html">HTML in TAR archive - this is recommended since this preserves all the formatting.</label>
                         </div>
 
                         <div class="form-check">


### PR DESCRIPTION
Changes `archiv` to `archive`.