### PR TITLE
add hotkey to copy contents with line breaks, fixes #349

### DIFF
--- a/src/public/javascripts/services/entrypoints.js
+++ b/src/public/javascripts/services/entrypoints.js
@@ -241,7 +241,7 @@ function registerEntrypoints() {
 
         d.showDialog(selectedOrActiveNodes);
     }));
-    
+
     keyboardActionService.setGlobalActionHandler("CreateNoteIntoDayNote", async () => {
         const todayNote = await dateNoteService.getTodayNote();
 
@@ -288,6 +288,9 @@ function registerEntrypoints() {
 
         searchNotesService.searchInSubtree(node.data.noteId);
     });
+
+    $('document').on('copy', utils.copySelectionToClipboard)
+    keyboardActionService.setGlobalActionHandler("CopyWithoutFormating", utils.copySelectionToClipboard)
 }
 
 export default {

--- a/src/public/javascripts/services/utils.js
+++ b/src/public/javascripts/services/utils.js
@@ -241,6 +241,13 @@ function getUrlForDownload(url) {
     }
 }
 
+function copySelectionToClipboard() {
+    const text = window.getSelection().toString()
+    if (navigator.clipboard) {
+        navigator.clipboard.writeText(text)
+    }
+}
+
 export default {
     reloadApp,
     parseDate,
@@ -273,5 +280,6 @@ export default {
     isHtmlEmpty,
     clearBrowserCache,
     getUrlForDownload,
-    normalizeShortcut
+    normalizeShortcut,
+    copySelectionToClipboard
 };

--- a/src/services/keyboard_actions.js
+++ b/src/services/keyboard_actions.js
@@ -306,6 +306,10 @@ const DEFAULT_KEYBOARD_ACTIONS = [
     {
         actionName: "ZoomIn",
         defaultShortcuts: ["CommandOrControl+="]
+    },
+    {
+        actionName: "CopyWithoutFormating",
+        defaultShortcuts: ["Alt+Ctrl+C"]
     }
 ];
 


### PR DESCRIPTION
Probably `Alt+Ctrl+C` is not the best hotkey though.
On breaks inserted with `shift+enter` it copies a single break line for each line.
On breaks inserted with just `enter` it copies double break line, which may be unwanted behavior.

Tested in latest version of Chrome and Firefox.