### PR TITLE
Fix corner case preventing notes from being created before ckeditor is initialized

### DIFF
--- a/src/public/javascripts/services/tree.js
+++ b/src/public/javascripts/services/tree.js
@@ -635,7 +635,7 @@ async function createNote(node, parentNoteId, target, extraOptions = {}) {
         extraOptions.saveSelection = false;
     }
 
-    if (extraOptions.saveSelection && window.cutToNote) {
+    if (extraOptions.saveSelection && utils.isCKEditorInitialized()) {
         [extraOptions.title, extraOptions.content] = parseSelectedHtml(window.cutToNote.getSelectedHtml());
     }
 
@@ -648,7 +648,7 @@ async function createNote(node, parentNoteId, target, extraOptions = {}) {
         type: extraOptions.type
     });
 
-    if (extraOptions.saveSelection && window.cutToNote) {
+    if (extraOptions.saveSelection && utils.isCKEditorInitialized()) {
         // we remove the selection only after it was saved to server to make sure we don't lose anything
         window.cutToNote.removeSelection();
     }

--- a/src/public/javascripts/services/tree.js
+++ b/src/public/javascripts/services/tree.js
@@ -635,7 +635,7 @@ async function createNote(node, parentNoteId, target, extraOptions = {}) {
         extraOptions.saveSelection = false;
     }
 
-    if (extraOptions.saveSelection) {
+    if (extraOptions.saveSelection && window.cutToNote) {
         [extraOptions.title, extraOptions.content] = parseSelectedHtml(window.cutToNote.getSelectedHtml());
     }
 
@@ -648,7 +648,7 @@ async function createNote(node, parentNoteId, target, extraOptions = {}) {
         type: extraOptions.type
     });
 
-    if (extraOptions.saveSelection) {
+    if (extraOptions.saveSelection && window.cutToNote) {
         // we remove the selection only after it was saved to server to make sure we don't lose anything
         window.cutToNote.removeSelection();
     }
@@ -870,7 +870,7 @@ window.glob.cutIntoNote = () => createNoteInto(true);
 
 keyboardActionService.setGlobalActionHandler('CutIntoNote', () => createNoteInto(true));
 
-keyboardActionService.setGlobalActionHandler('CreateNoteInto', createNoteInto);
+keyboardActionService.setGlobalActionHandler('CreateNoteInto', () => createNoteInto(true));
 
 keyboardActionService.setGlobalActionHandler('ScrollToActiveNote', scrollToActiveNote);
 

--- a/src/public/javascripts/services/utils.js
+++ b/src/public/javascripts/services/utils.js
@@ -248,6 +248,10 @@ function copySelectionToClipboard() {
     }
 }
 
+function isCKEditorInitialized() {
+    return !!(window && window.cutToNote);
+}
+
 export default {
     reloadApp,
     parseDate,
@@ -281,5 +285,6 @@ export default {
     clearBrowserCache,
     getUrlForDownload,
     normalizeShortcut,
-    copySelectionToClipboard
+    copySelectionToClipboard,
+    isCKEditorInitialized
 };


### PR DESCRIPTION
If Trilium is opened or reloaded on a note without any content, ckeditor will not be initialized. Attempting to create a note after or into at this point will cause this error:
`tree.js:639 Uncaught (in promise) TypeError: Cannot read property 'getSelectedHtml' of undefined
    at createNote (tree.js:639)
    at tree.js:808`

Fixed by checking if window.cutToNote is defined before using it.