### PR TITLE
Parse date in revisions dialog

### DIFF
--- a/src/public/app/dialogs/note_revisions.js
+++ b/src/public/app/dialogs/note_revisions.js
@@ -42,8 +42,9 @@ async function loadNoteRevisions(noteId, noteRevId) {
     revisionItems = await server.get(`notes/${noteId}/revisions`);
 
     for (const item of revisionItems) {
+        const formattedTime = utils.formatTime(utils.parseDate(item.dateLastEdited));
         $list.append($('<a class="dropdown-item" tabindex="0">')
-            .text(item.dateLastEdited.substr(0, 16) + ` (${item.contentLength} bytes)`)
+            .text(formattedTime + ` (${item.contentLength} bytes)`)
             .attr('data-note-revision-id', item.noteRevisionId));
     }
 


### PR DESCRIPTION
Hi,

I just started to use this tools which looks AMAZING but I noticed the dates in the revisions dialog are not shown using the correct timezone. This is an attempt to fix it.

Sadly I could not test it because it would not run. I tried on gitpod, and here is what I get (from you repo, with master):
```
> trilium@0.41.5 start-server /workspace/trilium
> TRILIUM_ENV=dev node ./src/www

Generated session secret
Generated sourceId=6a5PpyRWp0oy
App HTTP server starting up at port 8080
{
  "appVersion": "0.41.5",
  "dbVersion": 158,
  "syncVersion": 14,
  "buildDate": "2020-04-20T22:40:02+02:00",
  "buildRevision": "a86177bb597c752fbc96a24d4be7ab5ae6c0344d",
  "dataDirectory": "/home/gitpod/trilium-data",
  "clipperProtocolVersion": "1.0"
}
DB not initialized, please visit setup page - http://[your-server-host]:8080 to see instructions on how to initialize Trilium.
{ Error: Router not found for request /app-dist/setup.js
    at app.use (/workspace/trilium/src/app.js:84:17)
    at Layer.handle [as handle_request] (/workspace/trilium/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/workspace/trilium/node_modules/express/lib/router/index.js:317:13)
    at /workspace/trilium/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/workspace/trilium/node_modules/express/lib/router/index.js:335:12)
    at next (/workspace/trilium/node_modules/express/lib/router/index.js:275:10)
    at Layer.handle [as handle_request] (/workspace/trilium/node_modules/express/lib/router/layer.js:91:12)
    at trim_prefix (/workspace/trilium/node_modules/express/lib/router/index.js:317:13)
    at /workspace/trilium/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/workspace/trilium/node_modules/express/lib/router/index.js:335:12) status: 404 }
^CCaught interrupt signal. Exiting.
```