### PR TITLE
Prevent Note Info text from overlapping

### DIFF
--- a/src/public/app/widgets/collapsible_widgets/note_info.js
+++ b/src/public/app/widgets/collapsible_widgets/note_info.js
@@ -21,15 +21,15 @@ const TPL = `
     </style>
 
     <tr>
-        <th nowrap>Note ID:</th>
+        <th>Note ID:</th>
         <td nowrap colspan="3" class="note-info-note-id"></td>
     </tr>
     <tr>
-        <th nowrap>Created:</th>
+        <th>Created:</th>
         <td nowrap colspan="3" style="overflow: hidden; text-overflow: ellipsis;" class="note-info-date-created"></td>
     </tr>
     <tr>
-        <th nowrap>Modified:</th>
+        <th>Modified:</th>
         <td nowrap colspan="3" style="overflow: hidden; text-overflow: ellipsis;" class="note-info-date-modified"></td>
     </tr>
     <tr>


### PR DESCRIPTION
This makes all of the Note Info sections more consistent with each other. It prevents overlapping of text when the window is displayed in a small-width environment.

It turns this..

![Untitled](https://user-images.githubusercontent.com/10717998/81185400-88fb2380-8f7f-11ea-9886-ae581f0ae433.png)

Into this...
![image_11](https://user-images.githubusercontent.com/10717998/81185571-c069d000-8f7f-11ea-922e-26df7b537417.png)

