### PR TITLE
Fix Attribute.isOwned

### DIFF
--- a/src/public/app/entities/attribute.js
+++ b/src/public/app/entities/attribute.js
@@ -22,6 +22,10 @@ class Attribute {
         this.isInheritable = row.isInheritable;
     }
 
+    clone() {
+        return new Attribute(this.treeCache, this);
+    }
+
     /** @returns {NoteShort} */
     async getNote() {
         return await this.treeCache.getNote(this.noteId);

--- a/src/public/app/entities/note_short.js
+++ b/src/public/app/entities/note_short.js
@@ -158,8 +158,9 @@ class NoteShort {
      */
     getOwnedAttributes(type, name) {
         const attrs = this.attributes
-            .map(attributeId => this.treeCache.attributes[attributeId])
-            .filter(Boolean); // filter out nulls;
+            .map(attributeId => this.treeCache.attributes[attributeId].clone())
+            .filter(Boolean) // filter out nulls
+            .map(attr => Object.assign(attr, {isOwned: true}));
 
         return this.__filterAttrs(attrs, type, name);
     }
@@ -189,7 +190,9 @@ class NoteShort {
                 for (const parentNote of this.getParentNotes()) {
                     // these virtual parent-child relationships are also loaded into frontend tree cache
                     if (parentNote.type !== 'search') {
-                        attrArrs.push(parentNote.getInheritableAttributes());
+                        const parentAttr = parentNote.getInheritableAttributes()
+                            .map(attr => Object.assign(attr, {isOwned: false});
+                        attrArrs.push(parentAttr);
                     }
                 }
             }

--- a/src/public/app/entities/note_short.js
+++ b/src/public/app/entities/note_short.js
@@ -158,9 +158,9 @@ class NoteShort {
      */
     getOwnedAttributes(type, name) {
         const attrs = this.attributes
-            .map(attributeId => this.treeCache.attributes[attributeId].clone())
+            .map(attributeId => this.treeCache.attributes[attributeId])
             .filter(Boolean) // filter out nulls
-            .map(attr => Object.assign(attr, {isOwned: true}));
+            .map(attr => Object.assign(attr.clone(), {isOwned: true}));
 
         return this.__filterAttrs(attrs, type, name);
     }


### PR DESCRIPTION
`getOwnedAttributes` returns copy of attributes (to not edit the cache), with `isOwned` set to `true`. `getAttributes` takes care of setting `isOwned` to `false` for inherited attributes.

Fixes #1008

Tested with promoted attributes and inherited attributes (label-definition promoted and label, to check a child note cannot change a parent's attribute value). The behavior seems good to me.