### PR TITLE
Add a VSCode debug configuration matching the start-server npm script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "start-server",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "env": {
+                "TRILIUM_ENV": "dev"
+            },
+            "outputCapture": "std",
+            "program": "${workspaceFolder}/src/www"
+        }
+    ]
+}


### PR DESCRIPTION
This adds a configuration file so you can easily run the equivalent of the `start-server` script in the VSCode debugger.