### PR TITLE
Add import option to preserve line breaks in imported note content

### DIFF
--- a/src/public/app/dialogs/import.js
+++ b/src/public/app/dialogs/import.js
@@ -13,6 +13,7 @@ const $textImportedAsTextCheckbox = $("#text-imported-as-text-checkbox");
 const $codeImportedAsCodeCheckbox = $("#code-imported-as-code-checkbox");
 const $explodeArchivesCheckbox = $("#explode-archives-checkbox");
 const $replaceUnderscoresWithSpacesCheckbox = $("#replace-underscores-with-spaces-checkbox");
+const $preserveLineBreaksCheckbox = $("#preserve-line-breaks-checkbox");
 
 let parentNoteId = null;
 
@@ -25,6 +26,7 @@ export async function showDialog(noteId) {
     $codeImportedAsCodeCheckbox.prop("checked", true);
     $explodeArchivesCheckbox.prop("checked", true);
     $replaceUnderscoresWithSpacesCheckbox.prop("checked", true);
+    $preserveLineBreaksCheckbox.prop("checked", false);
 
     parentNoteId = noteId;
 
@@ -51,7 +53,8 @@ async function importIntoNote(parentNoteId) {
         textImportedAsText: boolToString($textImportedAsTextCheckbox),
         codeImportedAsCode: boolToString($codeImportedAsCodeCheckbox),
         explodeArchives: boolToString($explodeArchivesCheckbox),
-        replaceUnderscoresWithSpaces: boolToString($replaceUnderscoresWithSpacesCheckbox)
+        replaceUnderscoresWithSpaces: boolToString($replaceUnderscoresWithSpacesCheckbox),
+        preserveLineBreaks: boolToString($preserveLineBreaksCheckbox),
     };
 
     $dialog.modal('hide');

--- a/src/public/app/widgets/note_detail.js
+++ b/src/public/app/widgets/note_detail.js
@@ -97,7 +97,8 @@ export default class NoteDetailWidget extends TabAwareWidget {
                 textImportedAsText: true,
                 codeImportedAsCode: true,
                 explodeArchives: true,
-                replaceUnderscoresWithSpaces: true
+                replaceUnderscoresWithSpaces: true,
+                preserveLineBreaks: false,
             });
         });
 

--- a/src/public/app/widgets/note_tree.js
+++ b/src/public/app/widgets/note_tree.js
@@ -301,7 +301,8 @@ export default class NoteTreeWidget extends TabAwareWidget {
                             textImportedAsText: true,
                             codeImportedAsCode: true,
                             explodeArchives: true,
-                            replaceUnderscoresWithSpaces: true
+                            replaceUnderscoresWithSpaces: true,
+                            preserveLineBreaks: false,
                         });
                     }
                     else {

--- a/src/routes/api/import.js
+++ b/src/routes/api/import.js
@@ -22,7 +22,8 @@ async function importToBranch(req) {
         textImportedAsText: req.body.textImportedAsText !== 'false',
         codeImportedAsCode: req.body.codeImportedAsCode !== 'false',
         explodeArchives: req.body.explodeArchives !== 'false',
-        replaceUnderscoresWithSpaces: req.body.replaceUnderscoresWithSpaces !== 'false'
+        replaceUnderscoresWithSpaces: req.body.replaceUnderscoresWithSpaces !== 'false',
+        preserveLineBreaks: req.body.preserveLineBreaks !== 'false',
     };
 
     const file = req.file;

--- a/src/services/import/single.js
+++ b/src/services/import/single.js
@@ -119,7 +119,11 @@ async function importMarkdown(taskContext, file, parentNote) {
     const markdownContent = file.buffer.toString("UTF-8");
 
     const reader = new commonmark.Parser();
-    const writer = new commonmark.HtmlRenderer();
+    const htmlRendererOptions = {};
+    if(taskContext.data.preserveLineBreaks) {
+        htmlRendererOptions.softbreak = "<br />";
+    }
+    const writer = new commonmark.HtmlRenderer(htmlRendererOptions);
 
     const parsed = reader.parse(markdownContent);
     const htmlContent = writer.render(parsed);

--- a/src/services/import/tar.js
+++ b/src/services/import/tar.js
@@ -29,7 +29,11 @@ async function importTar(taskContext, fileBuffer, importRootNote) {
     // path => noteId
     const createdPaths = { '/': importRootNote.noteId, '\\': importRootNote.noteId };
     const mdReader = new commonmark.Parser();
-    const mdWriter = new commonmark.HtmlRenderer();
+    const htmlRendererOptions = {};
+    if(taskContext.data.preserveLineBreaks) {
+        htmlRendererOptions.softbreak = "<br />";
+    }
+    const mdWriter = new commonmark.HtmlRenderer(htmlRendererOptions);
     let metaFile = null;
     let firstNote = null;
 

--- a/src/services/import/zip.js
+++ b/src/services/import/zip.js
@@ -28,7 +28,11 @@ async function importZip(taskContext, fileBuffer, importRootNote) {
     // path => noteId, used only when meta file is not available
     const createdPaths = { '/': importRootNote.noteId, '\\': importRootNote.noteId };
     const mdReader = new commonmark.Parser();
-    const mdWriter = new commonmark.HtmlRenderer();
+    const htmlRendererOptions = {};
+    if(taskContext.data.preserveLineBreaks) {
+        htmlRendererOptions.softbreak = "<br />";
+    }
+    const mdWriter = new commonmark.HtmlRenderer(htmlRendererOptions);
     let metaFile = null;
     let firstNote = null;
     const createdNoteIds = {};

--- a/src/views/dialogs/import.ejs
+++ b/src/views/dialogs/import.ejs
@@ -61,6 +61,14 @@
                                 Replace underscores with spaces in imported note names
                             </label>
                         </div>
+
+                        <div class="checkbox">
+                            <label>
+                                <input id="preserve-line-breaks-checkbox" value="1" type="checkbox" checked>
+
+                                Preserve line breaks in imported note content
+                            </label>
+                        </div>
                     </div>
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
The option defaults to disabled, since line breaks are not supposed to be meaningful in markdown. (But they are meaningful in markdown exported from Zim.)