### PR TITLE
Add web app manifest

### DIFF
--- a/src/public/manifest.webmanifest
+++ b/src/public/manifest.webmanifest
@@ -1,10 +1,9 @@
 {
   "name": "Trilium",
   "short_name": "Trilium",
-  "theme_color": "#2196f3",
-  "background_color": "#2196f3",
-  "display": "standalone",
+  "theme_color": "DarkGray",
   "background_color": "DarkGray",
+  "display": "standalone",
   "scope": "/",
   "start_url": "/",
   "icons": [{

--- a/src/public/manifest.webmanifest
+++ b/src/public/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Trilium",
+  "short_name": "Trilium",
+  "theme_color": "#2196f3",
+  "background_color": "#2196f3",
+  "display": "standalone",
+  "background_color": "DarkGray",
+  "scope": "/",
+  "start_url": "/",
+  "icons": [{
+    "src": "images/app-icons/ios/apple-touch-icon.png",
+    "sizes": "180x180",
+    "type": "image/png"
+  }]
+}

--- a/src/views/mobile.ejs
+++ b/src/views/mobile.ejs
@@ -5,7 +5,7 @@
     <link rel="shortcut icon" href="favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title>Trilium Notes</title>
-    <link rel="apple-touch-icon" sizes="180x180" href="images/app-icons/ios/apple-touch-icon.png">
+    <link rel="manifest" href="manifest.webmanifest">
 
     <style>
         .lds-roller {


### PR DESCRIPTION
Add basic web app manifest.
Tested with Chrome and Firefox on Android 10.
After initial 'Add to Home screen' process, repeatedly launching app from home screen no longer opens multiple browser tabs.
I've been using this setup for the past week and data sync *might* be more consistent (with self-hosted Docker server instance).