### PR TITLE
Jump to note dialog: fix duplicate event triggers

### DIFF
--- a/src/public/app/dialogs/jump_to_note.js
+++ b/src/public/app/dialogs/jump_to_note.js
@@ -13,6 +13,8 @@ export async function showDialog() {
     utils.openDialog($dialog);
 
     noteAutocompleteService.initNoteAutocomplete($autoComplete, { hideGoToSelectedNoteButton: true })
+        // clear any event listener added in previous invocation of this function
+        .off('autocomplete:noteselected')
         .on('autocomplete:noteselected', function(event, suggestion, dataset) {
             if (!suggestion.notePath) {
                 return false;


### PR DESCRIPTION
This fixes an issue where the current path (above the note tree) displays parts multiple times, e.g. A / A / B / B instead of A / B.

The same issue could also affect other event handlers, but I didn't look around the codebase further.