### PR TITLE
Use user theme on mobile

### DIFF
--- a/src/views/mobile.ejs
+++ b/src/views/mobile.ejs
@@ -94,7 +94,7 @@
         }
     </style>
 </head>
-<body class="mobile">
+<body class="mobile theme-<%= theme %>">
 <noscript>Trilium requires JavaScript to be enabled.</noscript>
 
 <div id="toast-container" class="d-flex flex-column justify-content-center align-items-center"></div>


### PR DESCRIPTION
A small pet peeve I had when I transitioned from the stand-alone app to the server was that the chosen theme would only show when in desktop mode. From what I have seem theming doesn't seem to impact mobile layout (correct me if I am wrong @zadam ), so this quick change allows us to use glorious dark mode on our phones!