### PR TITLE
feat(build): Add github image action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: build our image
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: Create server-package.json
+        run: cat package.json | grep -v electron > server-package.json
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        id: docker_build
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: jokajak/trilium:latest
+          tag_with_ref: true
+
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: jokajak/trilium
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
This is a proof of concept to demonstrate what's possible. Any interest in this? Github can automagically publish to docker on push to branches or tags. You would have to update the target name, repository, and secrets. I copied the instructions from https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/ to start and then merged in instructions from https://docs.github.com/en/actions/guides/publishing-docker-images