### PR TITLE
Mobile view: iOS sizing/styling changes

### DIFF
--- a/src/public/app/layouts/mobile_layout.js
+++ b/src/public/app/layouts/mobile_layout.js
@@ -86,7 +86,6 @@ export default class MobileLayout {
             .setParent(appContext)
             .id('root-widget')
             .css('height', '100vh')
-            .css('display', 'block')
             .child(new ScreenContainer("tree", 'column')
                 .class("d-sm-flex d-md-flex d-lg-flex d-xl-flex col-12 col-sm-5 col-md-4 col-lg-4 col-xl-4")
                 .css("max-height", "100%")

--- a/src/public/app/layouts/mobile_layout.js
+++ b/src/public/app/layouts/mobile_layout.js
@@ -30,6 +30,12 @@ kbd {
 
 const FANCYTREE_CSS = `
 <style>
+.tree-wrapper {
+    max-height: 100%;
+    margin-top: 55px;
+    overflow-y: auto;
+}
+
 .fancytree-custom-icon {
     font-size: 2em;
 }
@@ -63,6 +69,13 @@ span.fancytree-expander {
     border-width: 2px;
     border-style: solid;
 }
+
+.tree-wrapper .collapse-tree-button, 
+.tree-wrapper .scroll-to-active-note-button, 
+.tree-wrapper .tree-settings-button {    
+    position: fixed;
+    margin-right: 16px;
+}
 </style>`;
 
 export default class MobileLayout {
@@ -74,8 +87,11 @@ export default class MobileLayout {
             .css('display', 'block')
             .child(new ScreenContainer("tree", 'column')
                 .class("d-sm-flex d-md-flex d-lg-flex d-xl-flex col-12 col-sm-5 col-md-4 col-lg-4 col-xl-4")
+                .css("max-height", "100%")
+                .css('padding-left', 0)
                 .child(new MobileGlobalButtonsWidget())
-                .child(new NoteTreeWidget("main").cssBlock(FANCYTREE_CSS)))
+                .child(new NoteTreeWidget("main")
+                    .cssBlock(FANCYTREE_CSS)))
             .child(new ScreenContainer("detail", "column")
                 .class("d-sm-flex d-md-flex d-lg-flex d-xl-flex col-12 col-sm-7 col-md-8 col-lg-8")
                 .css('max-height', '100%')

--- a/src/public/app/layouts/mobile_layout.js
+++ b/src/public/app/layouts/mobile_layout.js
@@ -34,6 +34,7 @@ const FANCYTREE_CSS = `
     max-height: 100%;
     margin-top: 55px;
     overflow-y: auto;
+    contain: content;
 }
 
 .fancytree-custom-icon {
@@ -75,6 +76,7 @@ span.fancytree-expander {
 .tree-wrapper .tree-settings-button {    
     position: fixed;
     margin-right: 16px;
+    display: none;
 }
 </style>`;
 
@@ -89,6 +91,7 @@ export default class MobileLayout {
                 .class("d-sm-flex d-md-flex d-lg-flex d-xl-flex col-12 col-sm-5 col-md-4 col-lg-4 col-xl-4")
                 .css("max-height", "100%")
                 .css('padding-left', 0)
+                .css('contain', 'content')
                 .child(new MobileGlobalButtonsWidget())
                 .child(new NoteTreeWidget("main")
                     .cssBlock(FANCYTREE_CSS)))
@@ -106,6 +109,7 @@ export default class MobileLayout {
                 .child(new NoteDetailWidget()
                     .css('padding', '5px 20px 10px 0')
                     .css('margin-top', '55px')
-                    .css('overflow-y', 'auto')));
+                    .css('overflow-y', 'auto')
+                    .css('contain', 'content')));
     }
 }

--- a/src/public/app/layouts/mobile_layout.js
+++ b/src/public/app/layouts/mobile_layout.js
@@ -24,6 +24,7 @@ kbd {
     font-size: 1.5em;
     padding-left: 0.5em;
     padding-right: 0.5em;
+    color: var(--main-text-color);
 }
 </style>`;
 

--- a/src/public/app/layouts/mobile_layout.js
+++ b/src/public/app/layouts/mobile_layout.js
@@ -71,19 +71,25 @@ export default class MobileLayout {
             .setParent(appContext)
             .id('root-widget')
             .css('height', '100vh')
+            .css('display', 'block')
             .child(new ScreenContainer("tree", 'column')
                 .class("d-sm-flex d-md-flex d-lg-flex d-xl-flex col-12 col-sm-5 col-md-4 col-lg-4 col-xl-4")
                 .child(new MobileGlobalButtonsWidget())
                 .child(new NoteTreeWidget("main").cssBlock(FANCYTREE_CSS)))
             .child(new ScreenContainer("detail", "column")
                 .class("d-sm-flex d-md-flex d-lg-flex d-xl-flex col-12 col-sm-7 col-md-8 col-lg-8")
+                .css('max-height', '100%')
                 .child(new FlexContainer('row').overflowing()
                     .css('font-size', 'larger')
                     .css('align-items', 'center')
+                    .css('position', 'fixed')
+                    .css('top', 0)
                     .child(new MobileDetailMenuWidget())
                     .child(new NoteTitleWidget())
                     .child(new CloseDetailButtonWidget()))
                 .child(new NoteDetailWidget()
-                    .css('padding', '5px 20px 10px 0')));
+                    .css('padding', '5px 20px 10px 0')
+                    .css('margin-top', '55px')
+                    .css('overflow-y', 'auto')));
     }
 }

--- a/src/public/app/widgets/mobile_widgets/mobile_global_buttons.js
+++ b/src/public/app/widgets/mobile_widgets/mobile_global_buttons.js
@@ -9,7 +9,7 @@ const WIDGET_TPL = `
         justify-content: space-around;
         padding: 0px 0 3px 0;
         font-size: larger;
-        position: fixed;
+        position: absolute;
         top: 8px;
         width: 100%;
     }

--- a/src/public/app/widgets/mobile_widgets/mobile_global_buttons.js
+++ b/src/public/app/widgets/mobile_widgets/mobile_global_buttons.js
@@ -7,9 +7,11 @@ const WIDGET_TPL = `
         display: flex;
         flex-shrink: 0;
         justify-content: space-around;
-        padding: 3px 0 3px 0;
-        margin: 0 10px 0 16px;
+        padding: 0px 0 3px 0;
         font-size: larger;
+        position: fixed;
+        top: 8px;
+        width: 100%;
     }
     </style>
 


### PR DESCRIPTION
### Changes
* Fix bug where action buttons were black and hard to see on dark themes due to Safari user agent styles
* Fix bug where you couldn't scroll on Safari (note detail view + tree view)
* Hopefully fix #1312 
* Note title and MobileGlobalButtonsWidget are now fixed at the top of the page even when you scroll; I added some margin so there's no overlap
* Hid floating buttons at bottom of tree view

### Tested on
* Firefox, Safari on iOS
* Windows Chrome + Firefox on responsive mode with Android user agents
* Tested that normal desktop view was unaffected
