### PR TITLE
Add mobile dropdown for plugin buttons

### DIFF
--- a/src/public/app/services/app_context.js
+++ b/src/public/app/services/app_context.js
@@ -34,9 +34,7 @@ class AppContext extends Component {
 
         this.tabManager.loadTabs();
 
-        if (utils.isDesktop()) {
-            setTimeout(() => bundleService.executeStartupBundles(), 2000);
-        }
+        setTimeout(() => bundleService.executeStartupBundles(), 2000);
     }
 
     showWidgets() {

--- a/src/public/app/services/bundle.js
+++ b/src/public/app/services/bundle.js
@@ -2,6 +2,7 @@ import ScriptContext from "./script_context.js";
 import server from "./server.js";
 import toastService from "./toast.js";
 import treeCache from "./tree_cache.js";
+import utils from "./utils.js";
 
 async function getAndExecuteBundle(noteId, originEntity = null) {
     const bundle = await server.get('script/bundle/' + noteId);
@@ -25,7 +26,8 @@ async function executeBundle(bundle, originEntity, $container) {
 }
 
 async function executeStartupBundles() {
-    const scriptBundles = await server.get("script/startup");
+    const isMobile = utils.isMobile();
+    const scriptBundles = await server.get("script/startup" + (isMobile ? "?mobile=true" : ""));
 
     for (const bundle of scriptBundles) {
         await executeBundle(bundle);

--- a/src/public/app/services/frontend_script_api.js
+++ b/src/public/app/services/frontend_script_api.js
@@ -108,7 +108,7 @@ function FrontendScriptApi(startNote, currentNote, originEntity = null, $contain
         if (utils.isMobile()) {
             $('#plugin-buttons-placeholder').remove();
             button = $('<a class="dropdown-item" href="#">')
-                .on('click', (...args) => {
+                .on('click', () => {
                     setTimeout(() => $pluginButtons.dropdown('hide'), 0);
                 });
         } else {

--- a/src/public/app/services/frontend_script_api.js
+++ b/src/public/app/services/frontend_script_api.js
@@ -104,9 +104,18 @@ function FrontendScriptApi(startNote, currentNote, originEntity = null, $contain
     this.addButtonToToolbar = opts => {
         const buttonId = "toolbar-button-" + opts.title.replace(/\s/g, "-");
 
-        const button = $('<button class="noborder">')
-            .addClass("btn btn-sm")
-            .on('click', opts.action);
+        let button;
+        if (utils.isMobile()) {
+            $('#plugin-buttons-placeholder').remove();
+            button = $('<a class="dropdown-item" href="#">')
+                .on('click', (...args) => {
+                    setTimeout(() => $pluginButtons.dropdown('hide'), 0);
+                });
+        } else {
+            button = $('<button class="noborder">')
+                .addClass("btn btn-sm");
+        }
+        button = button.on('click', opts.action);
 
         if (opts.icon) {
             button.append($("<span>").addClass("bx bx-" + opts.icon))

--- a/src/public/app/widgets/mobile_widgets/mobile_global_buttons.js
+++ b/src/public/app/widgets/mobile_widgets/mobile_global_buttons.js
@@ -40,7 +40,6 @@ const WIDGET_TPL = `
         <div class="dropdown-menu dropdown-menu-right">
             <a class="dropdown-item" data-trigger-command="switchToDesktopVersion"><span class="bx bx-laptop"></span> Switch to desktop version</a>
             <a class="dropdown-item" data-trigger-command="logout"><span class="bx bx-log-out"></span> Logout</a>
-            <a class="dropdown-item" ><span class="bx bx-log-out"></span> test</a>
         </div>
     </div>
 </div>

--- a/src/public/app/widgets/mobile_widgets/mobile_global_buttons.js
+++ b/src/public/app/widgets/mobile_widgets/mobile_global_buttons.js
@@ -13,6 +13,11 @@ const WIDGET_TPL = `
         top: 8px;
         width: 100%;
     }
+
+    #plugin-buttons-placeholder {
+        font-size: smaller;
+        padding: 5px;
+    }
     </style>
 
     <a data-trigger-command="createNoteIntoInbox" title="New note" class="icon-action bx bx-folder-plus"></a>
@@ -22,11 +27,20 @@ const WIDGET_TPL = `
     <a data-trigger-command="scrollToActiveNote" title="Scroll to active note" class="icon-action bx bx-crosshair"></a>
 
     <div class="dropdown">
+        <a title="Plugin buttons" class="icon-action bx bx-chip dropdown-toggle" data-toggle="dropdown"></a>
+
+        <div id="plugin-buttons" class="dropdown-menu dropdown-menu-right">
+            <p id="plugin-buttons-placeholder">No plugin buttons loaded yet.</p>
+        </div>
+    </div> 
+
+    <div class="dropdown">
         <a title="Global actions" class="icon-action bx bx-cog dropdown-toggle" data-toggle="dropdown"></a>
 
         <div class="dropdown-menu dropdown-menu-right">
             <a class="dropdown-item" data-trigger-command="switchToDesktopVersion"><span class="bx bx-laptop"></span> Switch to desktop version</a>
             <a class="dropdown-item" data-trigger-command="logout"><span class="bx bx-log-out"></span> Logout</a>
+            <a class="dropdown-item" ><span class="bx bx-log-out"></span> test</a>
         </div>
     </div>
 </div>

--- a/src/public/app/widgets/mobile_widgets/mobile_global_buttons.js
+++ b/src/public/app/widgets/mobile_widgets/mobile_global_buttons.js
@@ -27,7 +27,7 @@ const WIDGET_TPL = `
     <a data-trigger-command="scrollToActiveNote" title="Scroll to active note" class="icon-action bx bx-crosshair"></a>
 
     <div class="dropdown">
-        <a title="Plugin buttons" class="icon-action bx bx-chip dropdown-toggle" data-toggle="dropdown"></a>
+        <a title="Plugin buttons" class="icon-action bx bx-extension dropdown-toggle" data-toggle="dropdown"></a>
 
         <div id="plugin-buttons" class="dropdown-menu dropdown-menu-right">
             <p id="plugin-buttons-placeholder">No plugin buttons loaded yet.</p>

--- a/src/routes/api/script.js
+++ b/src/routes/api/script.js
@@ -58,7 +58,9 @@ function getStartupBundles(req) {
         if (req.query.mobile === "true") {
             return getBundlesWithLabel("run", "mobileStartup");
         }
-        return getBundlesWithLabel("run", "frontendStartup");
+        else {
+            return getBundlesWithLabel("run", "frontendStartup");
+        }
     }
     else {
         return [];

--- a/src/routes/api/script.js
+++ b/src/routes/api/script.js
@@ -53,8 +53,11 @@ function getBundlesWithLabel(label, value) {
     return bundles;
 }
 
-function getStartupBundles() {
+function getStartupBundles(req) {
     if (!process.env.TRILIUM_SAFE_MODE) {
+        if (req.query.mobile === "true") {
+            return getBundlesWithLabel("run", "mobileStartup");
+        }
         return getBundlesWithLabel("run", "frontendStartup");
     }
     else {


### PR DESCRIPTION
Re #1749 

## Changes
* `/scripts/startup` takes new optional `?mobile=true` query param that searches for notes where `#run=mobileStartup`
* App context no longer prevents mobile from making the call
* New toolbar dropdown button holds the `#plugin-buttons` container
* `addButtonToToolbar` frontend api fn checks for mobile and makes a few styling changes

![image](https://user-images.githubusercontent.com/4460805/111578834-de4cb780-8782-11eb-87e7-ded840bd2a0a.png)

Happy to rename the `#run=mobileStartup` attribute search or change the toolbar icon. Wasn't sure the best option for those.