### PR TITLE
If the database hasn't been initialized (new install?) don't attempt …

### DIFF
--- a/src/services/sync.js
+++ b/src/services/sync.js
@@ -391,8 +391,11 @@ sqlInit.dbReady.then(() => {
     setTimeout(cls.wrap(sync), 5000);
 });
 
-// called just so ws.setLastSyncedPush() is called
-getLastSyncedPush();
+if (sqlInit.isDbInitialized())
+{
+    // called just so ws.setLastSyncedPush() is called
+    getLastSyncedPush();
+}
 
 module.exports = {
     sync,


### PR DESCRIPTION
…to update our last synced id, as there is no db to grab it from (prevents running the server as a fresh install completely)

Fix for #1796