### PR TITLE
Avoid resetting all background properties on note-icons

### DIFF
--- a/src/public/app/widgets/note_icon.js
+++ b/src/public/app/widgets/note_icon.js
@@ -12,7 +12,7 @@ const TPL = `
     
     .note-icon-container button.note-icon {
         font-size: 180%;
-        background: transparent;
+        background-color: transparent;
         border: 1px solid transparent;
         cursor: pointer;
         padding: 6px;


### PR DESCRIPTION
I've been using [this technique](https://davi.dev/post/emoji-icons-on-trilium-notes/) to be able to use emojis as note icons. After upgrading to the latest Trilium version I noticed that the custom icons are still displayed on the sidebar, but not on the title of the opened note.

The reason is that the CSS I was using sets the icon using the `background-image` property and this gets overridden by the `background` property in the `.note-icon-container button.note-icon` rule. Since the rule is only setting the background color anyways, I think we can make it more specific and avoid overriding/resetting other properties.