### PR TITLE
Exit on SIGTERM

### DIFF
--- a/src/www
+++ b/src/www
@@ -8,10 +8,13 @@ process.on('unhandledRejection', error => {
     require('./services/log').info(error);
 });
 
-process.on('SIGINT', function() {
-	console.log("Caught interrupt signal. Exiting.");
-	process.exit();
-});
+function exit() {
+    console.log("Caught interrupt/termination signal. Exiting.");
+    process.exit(0);
+}
+
+process.on('SIGINT', exit);
+process.on('SIGTERM', exit);
 
 const { app, sessionParser } = require('./app');
 const fs = require('fs');


### PR DESCRIPTION
Stopping a systemd service running the server now works properly.

Previously, the server process didn't exit and was killed 90 seconds later.