### PR TITLE
Render math in zip/single export

### DIFF
--- a/src/services/export/single.js
+++ b/src/services/export/single.js
@@ -23,7 +23,11 @@ function exportSingleNote(taskContext, branch, format, res) {
     if (note.type === 'text') {
         if (format === 'html') {
             if (!content.toLowerCase().includes("<html")) {
-                content = '<html><head><meta charset="utf-8"></head><body>' + content + '</body></html>';
+            	// KaTeX Auto-render Extension — from https://katex.org/docs/autorender.html
+            	let katexRender = `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css" integrity="sha384-Um5gpz1odJg5Z4HAmzPtgZKdTBHZdw8S29IecapCSB31ligYPhHQZMIlWLYQGVoc" crossorigin="anonymous">
+					<script defer src="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.js" integrity="sha384-YNHdsYkH6gMx9y3mRkmcJ2mFUjTd0qNQQvY9VYZgQd7DcN7env35GzlmFaZ23JGp" crossorigin="anonymous"></script>
+					<script defer src="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/contrib/auto-render.min.js" integrity="sha384-vZTG03m+2yp6N6BNi5iM4rW4oIwk5DfcNdFfxkk9ZWpDriOkXX8voJBFrAO7MpVl" crossorigin="anonymous" onload="renderMathInElement(document.body);"></script>`;
+                content = '<!doctype html><html><head><meta charset="utf-8">' + katexRender + '</head><body>' + content + '</body></html>';
             }
 
             payload = html.prettyPrint(content, {indent_size: 2});

--- a/src/services/export/zip.js
+++ b/src/services/export/zip.js
@@ -232,12 +232,19 @@ function exportToZip(taskContext, branch, format, res) {
             if (!content.substr(0, 100).toLowerCase().includes("<html")) {
                 const cssUrl = "../".repeat(noteMeta.notePath.length - 1) + 'style.css';
 
+                // KaTeX Auto-render Extension — from https://katex.org/docs/autorender.html
+                let katexRender = `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css" integrity="sha384-Um5gpz1odJg5Z4HAmzPtgZKdTBHZdw8S29IecapCSB31ligYPhHQZMIlWLYQGVoc" crossorigin="anonymous">
+	<script defer src="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.js" integrity="sha384-YNHdsYkH6gMx9y3mRkmcJ2mFUjTd0qNQQvY9VYZgQd7DcN7env35GzlmFaZ23JGp" crossorigin="anonymous"></script>
+	<script defer src="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/contrib/auto-render.min.js" integrity="sha384-vZTG03m+2yp6N6BNi5iM4rW4oIwk5DfcNdFfxkk9ZWpDriOkXX8voJBFrAO7MpVl" crossorigin="anonymous" onload="renderMathInElement(document.body);"></script>`;
+
                 // <base> element will make sure external links are openable - https://github.com/zadam/trilium/issues/1289#issuecomment-704066809
-                content = `<html>
+                content = `<!doctype html>
+<html>
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="${cssUrl}">
+    ${katexRender}
     <base target="_parent">
 </head>
 <body class="ck-content">


### PR DESCRIPTION
Adds a snippet for KaTeX's Auto-render Extension ([docs](https://katex.org/docs/autorender.html)) to render equations on html note exports.

Adding `<!doctype html>` to `content` becomes necessary or else things fail:
`> Warning: KaTeX doesn't work in quirks mode. Make sure your website has a suitable doctype.`

### Example
<img width="798" alt="ss-210714-13 47 26" src="https://user-images.githubusercontent.com/6820950/125691550-c0bee67a-25f7-470e-b71c-4599e7a03b18.png">

#### Before
<img width="748" alt="ss-210714-13 48 22" src="https://user-images.githubusercontent.com/6820950/125691574-85f82d72-bde7-4536-b2ad-01530e5c150c.png">

#### After
<img width="766" alt="ss-210714-13 49 33" src="https://user-images.githubusercontent.com/6820950/125691590-720401f2-924b-4a5c-b812-df7be09604ee.png">

---

- Ok to add custom js into static page exports?
- Should snippet declaration be moved to avoid redundancy?
- Other math renderers do work, e.g. [MathJax](https://www.mathjax.org/#gettingstarted), with slightly different supported commands. Since it is KaTeX I assume their own web renderer is best.