### PR TITLE
Fix a bug in createNoteAfter

### DIFF
--- a/src/public/app/services/main_tree_executors.js
+++ b/src/public/app/services/main_tree_executors.js
@@ -41,6 +41,11 @@ export default class MainTreeExecutors extends Component {
 
     async createNoteAfterCommand() {
         const node = this.tree.getActiveNode();
+
+        if (!node) {
+            return;
+        }
+
         const parentNotePath = treeService.getNotePath(node.getParent());
         const isProtected = await treeService.getParentProtectedStatus(node);
 


### PR DESCRIPTION
Fixes a bug where invoking `createNoteAfter` while no node is currently selected in the note tree (ex: after opening a new tab) would cause an error.