### PR TITLE
Add shortcut to follow link under text cursor (#1842)

### DIFF
--- a/src/public/app/widgets/type_widgets/editable_text.js
+++ b/src/public/app/widgets/type_widgets/editable_text.js
@@ -7,6 +7,8 @@ import froca from "../../services/froca.js";
 import treeService from "../../services/tree.js";
 import noteCreateService from "../../services/note_create.js";
 import AbstractTextTypeWidget from "./abstract_text_type_widget.js";
+import link from "../../services/link.js";
+import appContext from "../../services/app_context.js";
 
 const ENABLE_INSPECTOR = false;
 
@@ -252,6 +254,21 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
         }
 
         return text;
+    }
+
+    async followLinkUnderCursorCommand() {
+        await this.initialized;
+
+        const selection = this.textEditor.model.document.selection;
+        if (!selection.hasAttribute('linkHref')) return;
+
+        const selectedLinkUrl = selection.getAttribute('linkHref');
+        const notePath = link.getNotePathFromUrl(selectedLinkUrl);
+        if (notePath) {
+            await appContext.tabManager.getActiveContext().setNote(notePath);
+        } else {
+            window.open(selectedLinkUrl, '_blank');
+        }
     }
 
     addIncludeNoteToTextCommand() {

--- a/src/services/keyboard_actions.js
+++ b/src/services/keyboard_actions.js
@@ -285,6 +285,12 @@ const DEFAULT_KEYBOARD_ACTIONS = [
         scope: "text-detail"
     },
     {
+        actionName: "followLinkUnderCursor",
+        defaultShortcuts: ["CommandOrControl+Enter"],
+        description: "Follow link within which the caret is placed",
+        scope: "text-detail"
+    },
+    {
         actionName: "insertDateTimeToText",
         defaultShortcuts: ["Alt+T"],
         scope: "text-detail"

--- a/src/views/dialogs/help.ejs
+++ b/src/views/dialogs/help.ejs
@@ -93,6 +93,7 @@
                                         <kbd data-command="scrollToActiveNote">not set</kbd> will switch back from editor to tree pane.</li>
                                     <li><kbd>Ctrl+K</kbd> - create / edit external link</li>
                                     <li><kbd data-command="addLinkToText">not set</kbd> - create internal link</li>
+                                    <li><kbd data-command="followLinkUnderCursor">not set</kbd> - follow link under cursor</li>
                                     <li><kbd data-command="insertDateTimeToText">not set</kbd> - insert current date and time at caret position</li>
                                     <li><kbd data-command="scrollToActiveNote">not set</kbd> - jump away to the tree pane and scroll to active note</li>
                                 </ul>


### PR DESCRIPTION
This pull request introduces a keyboard shortcut to follow the hyperlink located under the caret's position.

Thanks to @chee for their original workaround described in https://github.com/zadam/trilium/issues/1842#issuecomment-822053606 which inspired me to start this pull request.