### PR TITLE
Add shortcut to delete newly created note quickly

### DIFF
--- a/src/public/app/services/entrypoints.js
+++ b/src/public/app/services/entrypoints.js
@@ -80,7 +80,7 @@ export default class Entrypoints extends Component {
 
         await appContext.tabManager.openContextWithNote(note.noteId, true, null, hoistedNoteId);
 
-        appContext.triggerEvent('focusAndSelectTitle');
+        appContext.triggerEvent('focusAndSelectTitle', {isNewNote: true});
     }
 
     async toggleNoteHoistingCommand() {

--- a/src/public/app/services/note_create.js
+++ b/src/public/app/services/note_create.js
@@ -52,7 +52,7 @@ async function createNote(parentNotePath, options = {}) {
         await activeNoteContext.setNote(`${parentNotePath}/${note.noteId}`);
 
         if (options.focus === 'title') {
-            appContext.triggerEvent('focusAndSelectTitle',{isNewNote: true});
+            appContext.triggerEvent('focusAndSelectTitle', {isNewNote: true});
         }
         else if (options.focus === 'content') {
             appContext.triggerEvent('focusOnDetail', {ntxId: activeNoteContext.ntxId});

--- a/src/public/app/services/note_create.js
+++ b/src/public/app/services/note_create.js
@@ -52,7 +52,7 @@ async function createNote(parentNotePath, options = {}) {
         await activeNoteContext.setNote(`${parentNotePath}/${note.noteId}`);
 
         if (options.focus === 'title') {
-            appContext.triggerEvent('focusAndSelectTitle');
+            appContext.triggerEvent('focusAndSelectTitle',{isNewNote: true});
         }
         else if (options.focus === 'content') {
             appContext.triggerEvent('focusOnDetail', {ntxId: activeNoteContext.ntxId});


### PR DESCRIPTION
Sometimes a note is created from a misclick or for testing and we would like to delete it quickly. Currently you have to go to the note tree, select the note and hit delete.

This PR adds a shortcut when a newly created note is opened for the first time, so that pressing `escape` right after creating a new note will delete the note.