### PR TITLE
enex: Turn "Created with OneNote comment" into attribute

### DIFF
--- a/src/services/import/enex.js
+++ b/src/services/import/enex.js
@@ -221,6 +221,17 @@ function importEnex(taskContext, file, parentNote) {
 
         content = extractContent(content);
 
+        // This boilerplate is added by the Evernote import of OneNote notes (and preserved in ENEX export)
+        const replaced = content.replace(/<div>\s*<p>\s*<\/p>\s*<p>\s*Created with OneNote.\s*<\/p>\s*<\/div>\s*$/m, "");
+        if (replaced != content) {
+            content = replaced;
+            attributes.push({
+                type: 'label',
+                name: 'createdWithOneNote',
+                value: ''
+            });
+        }
+
         const noteEntity = noteService.createNewNote({
             parentNoteId: rootNote.noteId,
             title,


### PR DESCRIPTION
A boilerplate line is added by Evernote import. This converts the text
into an attribute.