### PR TITLE
Allow HTML nodes in mermaid diagrams

### DIFF
--- a/src/public/app/services/note_content_renderer.js
+++ b/src/public/app/services/note_content_renderer.js
@@ -97,7 +97,7 @@ async function getRenderedContent(note, options = {}) {
         const documentStyle = window.getComputedStyle(document.documentElement);
         const mermaidTheme = documentStyle.getPropertyValue('--mermaid-theme');
 
-        mermaid.mermaidAPI.initialize({ startOnLoad: false, theme: mermaidTheme.trim() });
+        mermaid.mermaidAPI.initialize({ startOnLoad: false, theme: mermaidTheme.trim(), securityLevel: 'antiscript' });
 
         try {
             mermaid.mermaidAPI.render("in-mermaid-graph-" + idCounter++, content,

--- a/src/public/app/widgets/mermaid.js
+++ b/src/public/app/widgets/mermaid.js
@@ -54,6 +54,7 @@ export default class MermaidWidget extends NoteContextAwareWidget {
         mermaid.mermaidAPI.initialize({
             startOnLoad: false,
             theme: mermaidTheme.trim(),
+            securityLevel: 'antiscript',
             flow: { useMaxWidth: false },
             sequence: { useMaxWidth: false },
             gantt: { useMaxWidth: false },


### PR DESCRIPTION
Security level is set to `antiscript` and not `loose` due to potential security vulnerability when importing notes.