### PR TITLE
Add option to copy note ID in context menu

### DIFF
--- a/src/public/app/services/tree_context_menu.js
+++ b/src/public/app/services/tree_context_menu.js
@@ -102,7 +102,9 @@ class TreeContextMenu {
             { title: "Export", command: "exportNote", uiIcon: "empty",
                 enabled: notSearch && noSelectedNotes },
             { title: "Import into note", command: "importIntoNote", uiIcon: "empty",
-                enabled: notSearch && noSelectedNotes }
+                enabled: notSearch && noSelectedNotes },
+            { title: "----" },
+            { title: "Copy note ID", command: "copyNoteId", enabled: noSelectedNotes, uiIcon: "hash" }
         ].filter(row => row !== null);
     }
 

--- a/src/public/app/widgets/note_tree.js
+++ b/src/public/app/widgets/note_tree.js
@@ -1433,4 +1433,13 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
             noteCreateService.duplicateSubtree(nodeToDuplicate.data.noteId, branch.parentNoteId);
         }
     }
+
+    copyNoteIdCommand({node}) {
+        // Use "real" clipboard to copy note ID as a string
+        navigator.permissions.query({name: "clipboard-write"}).then(result => {
+            if (result.state == "granted" || result.state == "prompt") {
+                navigator.clipboard.writeText(node.data.noteId);
+            }
+          });
+    }
 }


### PR DESCRIPTION
This can be useful e.g when copying an image note to get the URL to insert it into a mermaid diagram.