### PR TITLE
Add tag based multi arch docker build using GitHub Workflows

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,53 @@
+name: Publish Docker image
+on:
+  push:
+    tags: [v*]
+jobs:
+  push_to_registries:
+    name: Push Docker image to multiple registries
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            zadam/trilium
+            ghcr.io/zadam/trilium
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}-latest
+            type=match,pattern=(\d+.\d+).\d+\-beta,enable=${{ endsWith(github.ref, 'beta') }},group=1,suffix=-latest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create server-package.json
+        run: cat package.json | grep -v electron > server-package.json
+      - name: Build and Push
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          push: true
+          cache-from: type=registry,ref=zadam/trilium:buildcache
+          cache-to: type=registry,ref=zadam/trilium:buildcache,mode=max
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Hey,

I added a github workflow which should build multi-arch docker images for every new tag.
I also added the possibility to push the images to ghcr.io (GitHub Packages)

The tagging behaviour should be identically to the current [docker hub repo](https://hub.docker.com/r/zadam/trilium/tags)
When a new stable tag is published, e.g. 0.50.1, then the following tags will be created: 0.50.1, 0.50-latest, latest
When a new beta tag is published, e.g. 0.51.1-beta, then the following tags will be created: 0.51.1-beta, 0.51-latest

For the action to work, only the two secrets DOCKER_USERNAME & DOCKER_PASSWORD need to be created and filled in the repo settings. For ghcr.io to work, no secrets are needed, but i think the package visibility needs to be changed after the first build/push.

If this PR gets merged, one would possible need to update the release routine, as everything docker related is now done by GitHub.

You can see my test images [here](https://hub.docker.com/r/trann3l/trilium).
Would close #902