### PR TITLE
add heroku deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,6 @@
 /docs
 /npm-debug.log
 node_modules
+/heroku.dockerfile
+/app.json
+/heroku.yml

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+    "name": "trilium",
+    "description": "A barebones Node.js app using Express",
+    "repository": "https://github.com/zadam/trilium",
+    "logo": "https://github.com/zadam/trilium/raw/master/images/app-icons/png/512x512.png",
+    "keywords": ["node", "trilium", "trilium-server"]
+}

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "name": "trilium",
-    "description": "A barebones Node.js app using Express",
+    "description": "Build your personal knowledge base with Trilium Notes",
     "repository": "https://github.com/zadam/trilium",
     "logo": "https://github.com/zadam/trilium/raw/master/images/app-icons/png/512x512.png",
     "keywords": ["node", "trilium", "trilium-server"]

--- a/config-heroku.ini
+++ b/config-heroku.ini
@@ -1,0 +1,23 @@
+[General]
+# Instance name can be used to distinguish between different instances using backend api.getInstanceName()
+instanceName=
+
+# set to true to allow using Trilium without authentication (makes sense for server build only, desktop build doesn't need password)
+noAuthentication=false
+
+# set to true to disable backups (e.g. because of limited space on server)
+noBackup=true
+
+# Disable automatically generating desktop icon
+# noDesktopIcon=true
+
+[Network]
+# host setting is relevant only for web deployments - set the host on which the server will listen
+host=0.0.0.0
+# port setting is relevant only for web deployments, desktop builds run on a fixed port (changeable with TRILIUM_PORT environment variable)
+port=@PORT
+# true for TLS/SSL/HTTPS (secure), false for HTTP (unsecure).
+https=false
+# path to certificate (run "bash bin/generate-cert.sh" to generate self-signed certificate). Relevant only if https=true
+certPath=
+keyPath=

--- a/heroku.dockerfile
+++ b/heroku.dockerfile
@@ -1,0 +1,28 @@
+FROM node:14.18.1-alpine
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Bundle app source
+COPY . .
+RUN cat package.json | grep -v electron > server-package.json \
+    && cp server-package.json package.json
+
+# Install app dependencies
+RUN set -x \
+    && apk add --no-cache --virtual .build-dependencies \
+        autoconf \
+        automake \
+        g++ \
+        gcc \
+        libtool \
+        make \
+        nasm \
+        libpng-dev \
+        python \
+    && npm install --production \
+    && apk del .build-dependencies
+
+USER node
+
+CMD [ "/bin/sh", "-c", "mkdir ~/trilium-data && sed -r 's/@PORT/'$PORT'/' config-heroku.ini > ~/trilium-data/config.ini && node ./src/www" ]

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: heroku.dockerfile
+run:
+  web: /bin/sh -c "mkdir ~/trilium-data && sed -r 's/@PORT/'$PORT'/' config-heroku.ini > ~/trilium-data/config.ini && node ./src/www"


### PR DESCRIPTION
Hi, 
I create this PR for setup trilium in `heroku` service.

The reason for me to use this is I need to sync my data between sevrial computers in different place.
and i do not have an public IP address can be visited everywhere.
so I found heroku service.

### usage:

1. fork the repo in github
2. Create New App with heroku
3. in heroku app deploy tabs, link to gitlab & select your repo.
4. select `deploy branch`and wait it done.
5. finally, click `Open App` button, then you'll see the trilium web page.

### Shortcomings
1. when restart heroku dynos nothing can be keep, so this plan can only sync data temporary at this time.
I've try to solve this problem by trying mount webdav in docker, but It need more permisson to use `mount` command in docker.
not support by heroku.
then I try to modify trilium to use webdav to save every thing, then I found https://github.com/zadam/trilium/issues/242#issuecomment-442897744 seems like a difficult way too.
so I don't have any other idear to solve this problem.maybe we can solve it later.
