### PR TITLE
Add origin parameter

### DIFF
--- a/src/routes/api/clipper.js
+++ b/src/routes/api/clipper.js
@@ -43,7 +43,7 @@ function getClipperInboxNote() {
 }
 
 function addClipping(req) {
-    const {title, content, pageUrl, images} = req.body;
+    const {title, content, pageUrl, images, origin} = req.body;
 
     const clipperInbox = getClipperInboxNote();
 
@@ -59,6 +59,10 @@ function addClipping(req) {
 
         clippingNote.setLabel('clipType', 'clippings');
         clippingNote.setLabel('pageUrl', pageUrl);
+        if (origin) {
+            clippingNote.setLabel('origin', origin);
+
+        }
     }
 
     const rewrittenContent = processContent(images, clippingNote, content);
@@ -73,7 +77,7 @@ function addClipping(req) {
 }
 
 function createNote(req) {
-    let {title, content, pageUrl, images, clipType} = req.body;
+    let {title, content, pageUrl, images, clipType, origin} = req.body;
 
     if (!title || !title.trim()) {
         title = "Clipped note from " + pageUrl;
@@ -92,6 +96,9 @@ function createNote(req) {
 
     if (pageUrl) {
         note.setLabel('pageUrl', pageUrl);
+    }
+    if (origin) {
+        note.setLabel('origin', origin);
     }
 
     const rewrittenContent = processContent(images, note, content);

--- a/src/routes/api/clipper.js
+++ b/src/routes/api/clipper.js
@@ -61,7 +61,6 @@ function addClipping(req) {
         clippingNote.setLabel('pageUrl', pageUrl);
         if (origin) {
             clippingNote.setLabel('origin', origin);
-
         }
     }
 


### PR DESCRIPTION
Requires: https://github.com/zadam/trilium-web-clipper/pull/32

This allows for an "origin" attribute, so I can search all of my web saved notes by the domain. Example: 
![image](https://user-images.githubusercontent.com/69441971/137562116-7c61960f-c67b-49b7-b69c-6c60dc9d7cff.png)
So I would be able to search by this attribute to find any saved stories in this domain.

![image](https://user-images.githubusercontent.com/69441971/137562285-27298cf2-a9dc-46e8-9c1a-f89618bb442b.png)
![image](https://user-images.githubusercontent.com/69441971/137562347-d45f70e9-7d67-4967-92dd-677e0d3e68ca.png)
This then allows for searching by domain: 
![image](https://user-images.githubusercontent.com/69441971/137562429-b44076b0-1daf-44dc-828b-022f33784ad7.png)

Question: Should the attribute name be changed to `clipOrigin` or equivalent? Just a thought :p
