### PR TITLE
Display PDF in shared notes 

### DIFF
--- a/src/share/content_renderer.js
+++ b/src/share/content_renderer.js
@@ -76,7 +76,12 @@ function getContent(note) {
         content = `<img src="api/images/${note.noteId}/${note.title}?${note.utcDateModified}">`;
     }
     else if (note.type === 'file') {
-        content = `<button type="button" onclick="location.href='api/notes/${note.noteId}/download'">Download file</button>`;
+        if (note.mime === 'application/pdf') {
+            content = `<iframe height="800" width="800" src="api/notes/${note.noteId}/view"></iframe>`
+        }
+        else {
+            content = `<button type="button" onclick="location.href='api/notes/${note.noteId}/download'">Download file</button>`;
+        }
     }
     else if (note.type === 'book') {
         content = getChildrenList(note);
@@ -84,6 +89,7 @@ function getContent(note) {
     else {
         content = '<p>This note type cannot be displayed.</p>' + getChildrenList(note);
     }
+    // console.log(note);
 
     return content;
 }

--- a/src/share/content_renderer.js
+++ b/src/share/content_renderer.js
@@ -89,8 +89,7 @@ function getContent(note) {
     else {
         content = '<p>This note type cannot be displayed.</p>' + getChildrenList(note);
     }
-    // console.log(note);
-
+    
     return content;
 }
 

--- a/src/share/routes.js
+++ b/src/share/routes.js
@@ -78,6 +78,25 @@ function register(router) {
 
         res.send(note.getContent());
     });
+    router.get('/share/api/notes/:noteId/view', (req, res, next) => {
+        const {noteId} = req.params;
+        const note = shaca.getNote(noteId);
+
+        if (!note) {
+            return res.status(404).send(`Not found`);
+        }
+
+        const utils = require("../services/utils");
+
+        const filename = utils.formatDownloadTitle(note.title, note.type, note.mime);
+
+        // res.setHeader('Content-Disposition', utils.getContentDisposition(filename));
+
+        res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+        res.setHeader('Content-Type', note.mime);
+
+        res.send(note.getContent());
+    });
 }
 
 module.exports = {

--- a/src/share/routes.js
+++ b/src/share/routes.js
@@ -78,6 +78,7 @@ function register(router) {
 
         res.send(note.getContent());
     });
+    
     router.get('/share/api/notes/:noteId/view', (req, res, next) => {
         const {noteId} = req.params;
         const note = shaca.getNote(noteId);


### PR DESCRIPTION
Render PDF in share page. I had to add an API endpoint to remove the content-disposition header, otherwise the file would just be opened as a download. `api/notes/${note.noteId}/view` 

I wonder what else an iframe could embed. Maybe other mimetypes could be rendered like this. PDF was the obvious first target, though.