### PR TITLE
Style shared note children

### DIFF
--- a/src/views/share/page.ejs
+++ b/src/views/share/page.ejs
@@ -52,18 +52,19 @@
         <% if (note.hasChildren()) { %>
             <nav id="childLinks" class="<% if (isEmpty) { %>grid<% } else { %>list<% } %>">
                 <% if (!isEmpty) { %>
-                    <hr>
+                    <div id="noteClippedFrom">
                     <span>Child notes: </span>
+                    <ul>
+                        <% for (const childNote of note.getChildNotes()) { %>
+                            <li>
+                                <a href="<%= childNote.shareId %>"
+                                   class="type-<%= childNote.type %>"><%= childNote.title %></a>
+                            </li>
+                        <% } %>
+                    </ul>
+                </div>
                 <% } %>
 
-                <ul>
-                    <% for (const childNote of note.getChildNotes()) { %>
-                        <li>
-                            <a href="<%= childNote.shareId %>"
-                               class="type-<%= childNote.type %>"><%= childNote.title %></a>
-                        </li>
-                    <% } %>
-                </ul>
             </nav>
         <% } %>
     </div>


### PR DESCRIPTION
![Screenshot from 2022-01-02 17-42-32](https://user-images.githubusercontent.com/69441971/147891451-9e529065-d461-4de8-926b-4508f06e99a5.png)

I stole the CSS class from noteClippedFrom and moved the loop into the `if (!isEmpty)` loop. I think it looks nice and better separates the content vs the bottom info box. 

Previously: 
![Screenshot from 2022-01-02 17-48-59](https://user-images.githubusercontent.com/69441971/147891471-26285a60-ab40-4e88-8c47-1681e02b64fb.png)
