### PR TITLE
fix param validation

### DIFF
--- a/src/etapi/notes.js
+++ b/src/etapi/notes.js
@@ -162,7 +162,7 @@ function parseBoolean(obj, name) {
     return obj[name] === 'true';
 }
 
-function parseInteger(obj, name) {
+function parseOrderDirection(obj, name) {
     if (!(name in obj)) {
         return undefined;
     }
@@ -176,7 +176,7 @@ function parseInteger(obj, name) {
     return integer;
 }
 
-function parseOrderDirection(obj, name) {
+function parseInteger(obj, name) {
     if (!(name in obj)) {
         return undefined;
     }


### PR DESCRIPTION
I was writing a python client for ETAPI. I found the validation for "orderDirection" and "limit" cloud never pass. Turns out the validation function names are swapped.

![ksnip_20220210-161648](https://user-images.githubusercontent.com/6752679/153366952-94f9361d-66cc-467c-83fd-d893e1d9d17f.png)
