### PR TITLE
Bump base docker image for ARM stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # !!! Don't try to build this Dockerfile directly, run it through bin/build-docker.sh script !!!
-FROM node:16.14.2-alpine
+FROM node:17.1.0-alpine3.12
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
Fixes #2848. Haven't thoroughly tested, but the image this creates is at least able to run, which the existing images can't.