### PR TITLE
Fix docker data permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,19 @@ RUN set -x \
         nasm \
         libpng-dev \
         python3 \
+        wget \
     && npm install --production \
     && apk del .build-dependencies
+
+# Some setup tools need to be kept
+RUN apk add --no-cache su-exec
 
 # Bundle app source
 COPY . .
 
-USER node
+# Add application user and setup proper volume permissions
+RUN adduser -s /bin/false node; exit 0
 
+# Start the application
 EXPOSE 8080
-CMD [ "node", "./src/www" ]
+CMD [ "./start-docker.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN set -x \
         nasm \
         libpng-dev \
         python3 \
-        wget \
     && npm install --production \
     && apk del .build-dependencies
 

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+chown -R node:node /home/node
+su-exec node node ./src/www


### PR DESCRIPTION
This change addresses the issue mentioned in #2856 where manual tweaking of managed docker volumes is discouraged.

By setting the data directory owner with root permission and running the application as user `node`, we no longer need to create a globally accessible directory without compromising application security.