### PR TITLE
Fix TRILIUM_DATA_DIR permissions in start-docker.sh

### DIFF
--- a/start-docker.sh
+++ b/start-docker.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 chown -R node:node /home/node
+[ -d "$TRILIUM_DATA_DIR" ] && chown -R node:node "$TRILIUM_DATA_DIR"
 su-exec node node ./src/www


### PR DESCRIPTION
This improves consistency with setups that use a custom data dir location. The syntax is POSIX compliant and is a shorthand for `if [...]; then ... fi`.