### PR TITLE
Added the USER_UID & USER_GID env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN set -x \
     && apk del .build-dependencies
 
 # Some setup tools need to be kept
-RUN apk add --no-cache su-exec
+RUN apk add --no-cache su-exec shadow
 
 # Bundle app source
 COPY . .

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+[[ ! -z "${USER_UID}" ]] && usermod -u ${USER_UID} node || echo "No USER_UID specified, leaving 1000"
+[[ ! -z "${USER_GID}" ]] && groupmod -g ${USER_GID} node || echo "No USER_GID specified, leaving 1000"
+
 chown -R node:node /home/node
-[ -d "$TRILIUM_DATA_DIR" ] && chown -R node:node "$TRILIUM_DATA_DIR"
 su-exec node node ./src/www


### PR DESCRIPTION
Yea, the node user & the su-exec approach you had already made the resulting uid & gid be 1000.
But with this pr, you can set them to whatever, just by setting the env variables.

I will update the wiki too once this is merged.
Also, question, do you want me to add them to the provided compose yml?

Details about the changes:
 - Package shadow added, to provide usermod & groupmod.
 - Checks if the env variables are present and not empty, in that case, it uses them to edit user's "node" id's.
   The changed id's will reflect to the target files.