### PR TITLE
Fix docker image not exiting cleanly

### DIFF
--- a/start-docker.sh
+++ b/start-docker.sh
@@ -4,4 +4,4 @@
 [[ ! -z "${USER_GID}" ]] && groupmod -g ${USER_GID} node || echo "No USER_GID specified, leaving 1000"
 
 chown -R node:node /home/node
-su-exec node node ./src/www
+exec su-exec node node ./src/www


### PR DESCRIPTION
Fix #2919 

Signals will not be propagated to children so we have to exec the main process (su-exec).