### PR TITLE
fix typo on advanced options page

### DIFF
--- a/src/public/app/widgets/dialogs/options/advanced.js
+++ b/src/public/app/widgets/dialogs/options/advanced.js
@@ -34,7 +34,7 @@ const TPL = `
     
 <h5>Light anonymization</h5>
 
-<p>This action will create a new copy of the database and do a light anonymization on it - specifically only content of all notes will be removed, but titles and attributes will remaing. Additionally, custom JS frontend/backend script notes and custom widgets will remain. This provides more context to debug the issues.</p>
+<p>This action will create a new copy of the database and do a light anonymization on it - specifically only content of all notes will be removed, but titles and attributes will remain. Additionally, custom JS frontend/backend script notes and custom widgets will remain. This provides more context to debug the issues.</p>
 
 <p>You can decide yourself if you want to provide fully or lightly anonymized database. Even fully anonymized DB is very useful, however in some cases lightly anonymized database can speed up the process of bug identification and fixing.</p>
 


### PR DESCRIPTION
Changed "remaing" to "remain"