### PR TITLE
Remove period from left pane toggle button tooltip

### DIFF
--- a/src/public/app/widgets/buttons/left_pane_toggle.js
+++ b/src/public/app/widgets/buttons/left_pane_toggle.js
@@ -11,8 +11,8 @@ export default class LeftPaneToggleWidget extends ButtonWidget {
             : "bx-chevrons-right";
 
         this.settings.title = isLeftPaneVisible
-            ? "Hide panel."
-            : "Open panel.";
+            ? "Hide panel"
+            : "Open panel";
 
         this.settings.command = isLeftPaneVisible
             ? "hideLeftPane"


### PR DESCRIPTION
Just something small I noticed, without the period it is consistent with the other sidebar tooltips.