### PR TITLE
Add config setting to disable update check

### DIFF
--- a/src/public/app/widgets/buttons/global_menu.js
+++ b/src/public/app/widgets/buttons/global_menu.js
@@ -1,6 +1,7 @@
 import BasicWidget from "../basic_widget.js";
 import utils from "../../services/utils.js";
 import UpdateAvailableWidget from "./update_available.js";
+import options from "../../services/options.js";
 
 const TPL = `
 <div class="dropdown global-menu dropright">
@@ -156,12 +157,14 @@ export default class GlobalMenuWidget extends BasicWidget {
     }
 
     async updateVersionStatus() {
-        const latestVersion = await this.fetchLatestVersion();
+        if (!options.get("checkForUpdates")) {
+            const latestVersion = await this.fetchLatestVersion();
 
-        this.updateAvailableWidget.updateVersionStatus(latestVersion);
+            this.updateAvailableWidget.updateVersionStatus(latestVersion);
 
-        this.$updateToLatestVersionButton.toggle(latestVersion > glob.triliumVersion);
-        this.$updateToLatestVersionButton.find(".version-text").text(`Version ${latestVersion} is available, click to download.`);
+            this.$updateToLatestVersionButton.toggle(latestVersion > glob.triliumVersion);
+            this.$updateToLatestVersionButton.find(".version-text").text(`Version ${latestVersion} is available, click to download.`);
+        }
     }
 
     async fetchLatestVersion() {

--- a/src/public/app/widgets/buttons/global_menu.js
+++ b/src/public/app/widgets/buttons/global_menu.js
@@ -157,7 +157,7 @@ export default class GlobalMenuWidget extends BasicWidget {
     }
 
     async updateVersionStatus() {
-        if (!options.get("checkForUpdates")) {
+        if (options.get("checkForUpdates") == 'true') {
             const latestVersion = await this.fetchLatestVersion();
 
             this.updateAvailableWidget.updateVersionStatus(latestVersion);

--- a/src/public/app/widgets/dialogs/options/other.js
+++ b/src/public/app/widgets/dialogs/options/other.js
@@ -116,7 +116,17 @@ const TPL = `
         <label for="auto-readonly-size-code">Automatic readonly size (code notes)</label>
         <input class="form-control" id="auto-readonly-size-code" type="number" min="0">
     </div>
-</div>`;
+</div>
+<div>
+<h4>Network connections</h4>
+    
+<div class="form-group">
+    <input id="check-for-updates" type="checkbox" name="check-for-updates">
+    <label for="check-for-updates">Check for updates automatically</label>
+</div>
+</div>
+
+`;
 
 export default class ProtectedSessionOptions {
     constructor() {
@@ -142,7 +152,7 @@ export default class ProtectedSessionOptions {
         this.$availableLanguageCodes = $("#available-language-codes");
 
         if (utils.isElectron()) {
-            const {webContents} = utils.dynamicRequire('@electron/remote').getCurrentWindow();
+            const { webContents } = utils.dynamicRequire('@electron/remote').getCurrentWindow();
 
             this.$availableLanguageCodes.text(webContents.session.availableSpellCheckerLanguages.join(', '));
         }
@@ -250,6 +260,14 @@ export default class ProtectedSessionOptions {
 
             this.setImageCompression(isChecked);
         });
+
+        this.$checkForUpdates = $("#check-for-updates");
+        this.$checkForUpdates.on("change", () => {
+            const isChecked = this.$checkForUpdates.prop("checked");
+            const opts = { 'checkForUpdates': isChecked ? 'true' : 'false' };
+
+            server.put('options', opts).then(() => toastService.showMessage("Options changed have been saved."));
+        });
     }
 
     optionsLoaded(options) {
@@ -272,5 +290,10 @@ export default class ProtectedSessionOptions {
         const compressImages = options['compressImages'] === 'true';
         this.$enableImageCompression.prop('checked', compressImages);
         this.setImageCompression(compressImages);
+
+
+        const checkForUpdates = options['checkForUpdates'] === 'true';
+        this.$checkForUpdates.prop('checked', checkForUpdates);
+
     }
 }

--- a/src/routes/api/options.js
+++ b/src/routes/api/options.js
@@ -57,7 +57,8 @@ const ALLOWED_OPTIONS = new Set([
     'maxContentWidth',
     'compressImages',
     'downloadImagesAutomatically',
-    'minTocHeadings'
+    'minTocHeadings',
+    'checkForUpdates'
 ]);
 
 function getOptions() {

--- a/src/routes/login.js
+++ b/src/routes/login.js
@@ -37,7 +37,7 @@ function setPassword(req, res) {
         return;
     }
 
-    options.setOption("checkForUpdates", req.body['check-for-updates'] == true);
+    options.setOption("checkForUpdates", req.body['check-for-updates'] == 'on');
     passwordService.setPassword(password1);
 
     res.redirect('login');

--- a/src/routes/login.js
+++ b/src/routes/login.js
@@ -5,6 +5,7 @@ const optionService = require('../services/options');
 const myScryptService = require('../services/my_scrypt');
 const log = require('../services/log');
 const passwordService = require("../services/password");
+const options = require('../services/options');
 
 function loginPage(req, res) {
     res.render('login', { failedAuth: false });
@@ -36,6 +37,7 @@ function setPassword(req, res) {
         return;
     }
 
+    options.setOption("checkForUpdates", req.body['check-for-updates'] == true);
     passwordService.setPassword(password1);
 
     res.redirect('login');

--- a/src/services/options_init.js
+++ b/src/services/options_init.js
@@ -85,7 +85,8 @@ const defaultOptions = [
     { name: 'maxContentWidth', value: '1200', isSynced: false },
     { name: 'compressImages', value: 'true', isSynced: true },
     { name: 'downloadImagesAutomatically', value: 'true', isSynced: true },
-    { name: 'minTocHeadings', value: '5', isSynced: true }
+    { name: 'minTocHeadings', value: '5', isSynced: true },
+    { name: 'checkForUpdates', value: 'true', isSynced: true },
 ];
 
 function initStartupOptions() {

--- a/src/views/set_password.ejs
+++ b/src/views/set_password.ejs
@@ -34,6 +34,11 @@
                 </div>
             </div>
             <div class="form-group">
+                <input id="check-for-updates" type="checkbox" name="check-for-updates">
+                <label for="check-for-updates">Check for updates automatically</label>
+            </div>
+
+            <div class="form-group">
                 <button class="btn btn-success">Set password</button>
             </div>
         </form>

--- a/src/views/set_password.ejs
+++ b/src/views/set_password.ejs
@@ -34,7 +34,7 @@
                 </div>
             </div>
             <div class="form-group">
-                <input id="check-for-updates" type="checkbox" name="check-for-updates">
+                <input checked id="check-for-updates" type="checkbox" name="check-for-updates">
                 <label for="check-for-updates">Check for updates automatically</label>
             </div>
 


### PR DESCRIPTION
Fixes https://github.com/zadam/trilium/discussions/2999

I was going to add this to the config.ini instead of options but I didn't find a way to access the config from the UI.

During initial setup, the user will be prompted at the password page to set whether Trilium Notes will automatically check for updates.
![image](https://user-images.githubusercontent.com/69441971/179847400-b080d250-e3f4-42b3-9c9c-9609d26177a0.png)
This way, if a user wants zero external connections, they can disable it from the beginning rather than having to open the UI (making that connection) to disable it.