### PR TITLE
Add optional support to trust reverse proxies (via X-Forwarded-For)

### DIFF
--- a/config-sample.ini
+++ b/config-sample.ini
@@ -21,3 +21,9 @@ https=false
 # path to certificate (run "bash bin/generate-cert.sh" to generate self-signed certificate). Relevant only if https=true
 certPath=
 keyPath=
+# setting to give trust to reverse proxies, a comma-separated list of trusted rev. proxy IPs can be specified (CIDR notation is permitted),
+# alternatively 'true' will make use of the leftmost IP in X-Forwarded-For, ultimately an integer can be used to tell about the number of hops between
+# Trilium (which is hop 0) and the first trusted rev. proxy. 
+# once set, expressjs will use the X-Forwarded-For header set by the rev. proxy to determinate the real IPs of clients.
+# expressjs shortcuts are supported: loopback(127.0.0.1/8, ::1/128), linklocal(169.254.0.0/16, fe80::/10), uniquelocal(10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7)
+trustedReverseProxy=false

--- a/src/www
+++ b/src/www
@@ -44,6 +44,14 @@ async function startTrilium() {
     app.set('port', usedPort);
     app.set('host', usedHost);
 
+    // Check from config whether to trust reverse proxies to supply user IPs, hostnames and protocols
+    if (config['Network']['trustedReverseProxy']) {
+        if (config['Network']['trustedReverseProxy'] === true || config['Network']['trustedReverseProxy'].trim().length) {
+            app.set('trust proxy', config['Network']['trustedReverseProxy'])
+        }
+    }
+    log.info('Trusted reverse proxy: ' + app.get('trust proxy'))
+
     if (config['Network']['https']) {
         if (!config['Network']['keyPath'] || !config['Network']['keyPath'].trim().length) {
             throw new Error("keyPath in config.ini is required when https=true, but it's empty");


### PR DESCRIPTION
Hello, this PR intends to introduce support for trusting reverse proxy supplied IPs (of clients), hostname and protocol.

This is accomplished by using expressjs built-in support for this.

The involved headers should be: X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto; they should be set accordingly by a trusted and properly configured rev. proxy which should override/manipulate these headers from an untrusted source.
From the node server side, more information about how expressjs does all this can be found here: https://expressjs.com/en/guide/behind-proxies.html.

The main advantages of properly configuring all this are:
- The real client IPs are presented when Trilium is behind a rev. proxy (i. e. to log failed login attempts)
- It's not possible anymore to cause DoS on the /login route by hitting the rate limiter limit, causing Trilium to set a cooldown timer which affects the reverse proxy IP where all traffic (depends on configuration, but most likely) comes from. Even tho a previously authenticated Trilium user wouldn't notice any issue at all.

expressjs implementation (as many others) allows:
- To blindly trust the first hop (which should be a rev. proxy, leftmost part of X-Forwarded-For), by setting ‘true’
- To specify the IPs (CIDR is supported as well) of the trusted reverse proxies (I guess it's the most recommended approach)
- To specify the rev. proxies to trust by specifying their position in 'hops' counted from Trilium server (which is hop 0)

If the IP of traffic doesn't match a specified trusted one expressjs will present it to Trilium with the socket IP as usual.

In order to record the aforementioned information I took the freedom to add a new setting named ‘trustedReverseProxy’ under the [Network] section in the config*.ini file. I guess I went a bit verbose with the commenting there, optionally it could be stripped and moved to a wiki page.

In addition I'm printing the 'trust proxy' config to stdout as a commodity, even tho this might cause people to accidentally leak those IPs while sharing their logs (which could potentially be public IPs), I'm not sure whether to leave it or not.

From a security perspective all this should be useful, however it introduces the risk of users unwillingly misconfiguring the setting. Currently the resulting dangers would be quite limited, malicious parties would be able to spoof IPs (potentially reflected in logs) and bypass any rate limiters and other stuff (possibly further easing brute-force attacks, which in the current state of things are currently fully prevented thanks to Trilium locking down the /login route for _everybody_ if behind a rev. proxy :S).

It should be noted that unfortunately, during testing, I discovered that a trusted proxy, whether misconfigued or not, (for expressjs) is allowed to write whatever stuff it wants in X-Forwarded-For(didn't look at the other two), including letters and whatever and expressjs will eat it regardless. This is annoying and likely dangerous to some extent because, such as in the case of failed logins (i.e. unauthenticated users), this arbitrary stuff ends up written to stdout and eventually in logs… I'm not sure whether I'm missing something or it's all regular.
Either way, as long as users _ensure_ to set the correct trusted IPs it shouldn't be a problem.

Be aware that I have 0 experience with all this, I just briefly looked it up in the docs to implement it here, so be wary of everything.

Also, while I did some very basic testing it would be much better if somebody could do tests too this before merging.