### PR TITLE
Fix max content width not working (fixes #3056)

### DIFF
--- a/src/public/app/widgets/note_wrapper.js
+++ b/src/public/app/widgets/note_wrapper.js
@@ -10,12 +10,6 @@ export default class NoteWrapperWidget extends FlexContainer {
             .collapsible();
     }
 
-    doRender() {
-        super.doRender();
-
-        this.$widget.addClass("note-split");
-    }
-
     setNoteContextEvent({noteContext}) {
         this.noteContext = noteContext;
 
@@ -42,6 +36,7 @@ export default class NoteWrapperWidget extends FlexContainer {
             return;
         }
 
+        this.$widget.addClass("note-split");
         this.$widget.toggleClass("full-content-width",
             ['image', 'mermaid', 'book', 'render', 'canvas', 'web-view'].includes(note.type)
             || !!note?.hasLabel('fullContentWidth')


### PR DESCRIPTION
The regression was introduced by commit 8acd3851b0a5ef40fb33b8a345efcc63e429e39e since the note-split class is added in the beginning of the rendering, but is removed on the first `refresh()`.

Moving the `this.$widget.addClass("note-split");` to the `refresh` method solves this issue.

Full width notes are not affected by the change.