### PR TITLE
Fix UTF-8 file name encoding for uploads (fixes #3013)

### DIFF
--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -4,7 +4,14 @@ const setupRoute = require('./setup');
 const loginRoute = require('./login');
 const indexRoute = require('./index');
 const utils = require('../services/utils');
-const multer = require('multer')();
+const multer = require('multer')({
+    fileFilter: (req, file, cb) => {
+        // UTF-8 file names are not well decoded by multer/busboy, so we handle the conversion on our side.
+        // See https://github.com/expressjs/multer/pull/1102.
+        file.originalname = Buffer.from(file.originalname, "latin1").toString("utf-8");
+        cb(null, true);
+    }
+});
 
 // API routes
 const treeApiRoute = require('./api/tree');


### PR DESCRIPTION
Attempting to upload a note containing UTF-8 characters will result in a wrong interpretation of the name. It can easily be tested by creating a file called `Helău world.txt` and trying to upload it.

Not a client problem, since the payload looks fine:
```
-----------------------------35722791636796930272418934920
Content-Disposition: form-data; name="upload"; filename="Helău.txt"
Content-Type: text/plain

 Helău world
```

The parsing gets worse in the server:

```
{
  fieldname: 'upload',
  originalname: 'HelÄ\x83u.txt',
  encoding: '7bit',
  mimetype: 'text/plain',
  buffer: <Buffer 20 48 65 6c c4 83 75 20 77 6f 72 6c 64 0a>,
  size: 14
}
```

Seems like there's an entire story regarding why UTF-8 characters are not well parsed:

- Browsers do not always respect a special header to allow UTF-8 file names.
- We are using multer as the Express middleware to process the files for us.
- Someone raised this exact issue in https://github.com/expressjs/multer/issues/1082.
- Seems that multer is using busboy.
- Someone from busboy changed the default from UTF-8 to Latin-7, but allowing the developer to change it.
- The multer library does not change it back to UTF-8 and neither do they allow the developer to change it.
- Someone made a PR in multer to allow fix this (https://github.com/expressjs/multer/pull/1102/files), but it hasn't been merged since Jun 2nd.

The change on the server side is rather trivial: enforce UTF-8 encoding. This fixes the issue and does not seem to introduce any regressions. Tested locally and it now parses the name correctly.