### PR TITLE
Fix relation map crash on missing inverse pair (fixes #3055)

### DIFF
--- a/src/routes/api/notes.js
+++ b/src/routes/api/notes.js
@@ -181,6 +181,7 @@ function getRelationMap(req) {
 
             if (def.inverseRelation) {
                 resp.inverseRelations[relationDefinition.getDefinedName()] = def.inverseRelation;
+                resp.inverseRelations[def.inverseRelation] = relationDefinition.getDefinedName();
             }
         }
     }


### PR DESCRIPTION
Fixes a case in which the relation map would crash if there was a relation definition with an inverse, but the inverse was not defined. See #3055 for more information, including steps to reproduce.