### PR TITLE
Fix "Cannot read properties of undefined (reading 'includes') when jumping to notes"

### DIFF
--- a/src/services/search/expressions/note_flat_text.js
+++ b/src/services/search/expressions/note_flat_text.js
@@ -31,7 +31,7 @@ class NoteFlatTextExp extends Expression {
                 return;
             }
 
-            if (!note.parents.length === 0 || note.noteId === 'root') {
+            if (note.parents.length === 0 || note.noteId === 'root') {
                 return;
             }
 


### PR DESCRIPTION
Solves "Cannot read properties of undefined (reading 'includes')".

Sometimes when looking for notes using “Jump to note” there is a toast notification indicating an error. Although it doesn't break the search functionality that much, it can be rather annoying. 

Frontend error:

```text-plain
Uncaught (in promise) Error: Error when calling GET autocomplete?query=hello%20w&activeNoteId=5NgNWpdpndEr: error - Cannot read properties of undefined (reading 'includes')
    throwError http://localhost:8080/app/services/toast.js:90
    reportError http://localhost:8080/app/services/server.js:110
```

Backend error:

```text-plain
200 GET /api/autocomplete?query=hello%20&activeNoteId=5NgNWpdpndEr with 2 bytes took 4ms
ERROR: get /api/autocomplete threw exception: TypeError: Cannot read properties of undefined (reading 'includes')
    at searchDownThePath (/home/elian/Projects/Trilium Dev/trilium/src/services/search/expressions/note_flat_text.js:41:31)
    at NoteFlatTextExp.execute (/home/elian/Projects/Trilium Dev/trilium/src/services/search/expressions/note_flat_text.js:114:21)
    at AndExp.execute (/home/elian/Projects/Trilium Dev/trilium/src/services/search/expressions/and.js:26:42)
    at findResultsWithExpression (/home/elian/Projects/Trilium Dev/trilium/src/services/search/services/search.js:77:32)
    at findResultsWithQuery (/home/elian/Projects/Trilium Dev/trilium/src/services/search/services/search.js:173:12)
    at Object.searchNotesForAutocomplete (/home/elian/Projects/Trilium Dev/trilium/src/services/search/services/search.js:194:30)
    at getAutocomplete (/home/elian/Projects/Trilium Dev/trilium/src/routes/api/autocomplete.js:22:33)
    at Function.cb (/home/elian/Projects/Trilium Dev/trilium/src/routes/routes.js:159:34)
    at Function.sqliteTransaction (/home/elian/Projects/Trilium Dev/trilium/node_modules/better-sqlite3/lib/methods/transaction.js:65:24)
    at Object.transactional (/home/elian/Projects/Trilium Dev/trilium/src/services/sql.js:236:52)
JS Error: Error when calling GET autocomplete?query=hello%20w&activeNoteId=5NgNWpdpndEr: error - Cannot read properties of undefined (reading 'includes')
```

Was able to reproduce the issue only with a lightly anonymized database.

Added logs:

```diff
diff --git a/src/services/search/expressions/note_flat_text.js b/src/services/search/expressions/note_flat_text.js
index ca5f2c59..813d7626 100644
--- a/src/services/search/expressions/note_flat_text.js
+++ b/src/services/search/expressions/note_flat_text.js
@@ -38,8 +38,13 @@ class NoteFlatTextExp extends Expression {
             const foundAttrTokens = [];
 
             for (const token of tokens) {
-                if (note.type.includes(token) || note.mime.includes(token)) {
-                    foundAttrTokens.push(token);
+                try {
+                    if (note.type.includes(token) || note.mime.includes(token)) {
+                        foundAttrTokens.push(token);
+                    }
+                } catch (e) {
+                    console.log("Failed at note: ", note);
+                    throw e;
                 }
             }
```

Turns out the offending note looks quite strange:

```text-plain
Failed at note:  Note {
  noteId: 'none',
  title: undefined,
  isProtected: false,
  type: undefined,
  mime: undefined,
  dateCreated: '2022-08-14 19:00:06.476+0300',
  dateModified: undefined,
  utcDateCreated: '2022-08-14 16:00:06.477Z',
  utcDateModified: undefined,
  isDecrypted: true,
  flatTextCache: null,
  parentBranches: [],
  parents: [],
  children: [],
  ownedAttributes: [],
  __attributeCache: null,
  inheritableAttributeCache: null,
  targetRelations: [],
  ancestorCache: null,
  contentSize: null,
  noteSize: null,
  revisionCount: null
}
```

Looking inside the SQLite database did not reveal anything of interest. There is no note called “none”, so we have to check where that comes from.

When searching for “hello”, the issue does not occur. It only happens when multiple words are added (e.g. “hello w”). So it seems that something related to `AndExp` is breaking the search.

Early log indicates:

```text-plain
Note none - "undefined" has no parents.
Note none - "undefined" has no parents.
```

Trace for that message:

```text-plain
Trace
    at getSomePathInner (/home/elian/Projects/Trilium Dev/trilium/src/becca/becca_service.js:146:17)
    at Object.getSomePath (/home/elian/Projects/Trilium Dev/trilium/src/becca/becca_service.js:128:12)
    at searchDownThePath (/home/elian/Projects/Trilium Dev/trilium/src/services/search/expressions/note_flat_text.js:22:46)
    at NoteFlatTextExp.execute (/home/elian/Projects/Trilium Dev/trilium/src/services/search/expressions/note_flat_text.js:120:21)
    at AndExp.execute (/home/elian/Projects/Trilium Dev/trilium/src/services/search/expressions/and.js:26:42)
    at findResultsWithExpression (/home/elian/Projects/Trilium Dev/trilium/src/services/search/services/search.js:77:32)
    at findResultsWithQuery (/home/elian/Projects/Trilium Dev/trilium/src/services/search/services/search.js:173:12)
    at Object.searchNotesForAutocomplete (/home/elian/Projects/Trilium Dev/trilium/src/services/search/services/search.js:194:30)
    at getAutocomplete (/home/elian/Projects/Trilium Dev/trilium/src/routes/api/autocomplete.js:22:33)
    at Function.cb (/home/elian/Projects/Trilium Dev/trilium/src/routes/routes.js:159:34)
```

Replacing the guard condition in `note_flat_text.js`:

```javascript
if (!note.parents.length === 0 || note.noteId === 'root') {
    return;
}
```

with:

```javascript
if (note.parents.length === 0 || note.noteId === 'root') {
    return;
}
```

fixes the issue.

Basic regression testing: checking that multi-word searches work, mime type and attribute check still working.

It seems that the issue was introduced by commit 7ac2206 (May 2020), which replaced the guard condition introduced by 2a53bb0 (Aug 2018):

```javascript
const parents = childToParent[noteId];
if (!parents || noteId === 'root') {
    return;
}
```

by:

```javascript
if (!note.parents.length === 0 || noteId === 'root') {
    return;
}
```