### PR TITLE
Add compression middleware

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ const favicon = require('serve-favicon');
 const cookieParser = require('cookie-parser');
 const helmet = require('helmet');
 const session = require('express-session');
+const compression = require('compression')
 const FileStore = require('session-file-store')(session);
 const sessionSecret = require('./services/session_secret');
 const dataDir = require('./services/data_dir');
@@ -17,6 +18,9 @@ const app = express();
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');
+
+// add compression
+app.use(compression())
 
 app.use(helmet({
     hidePoweredBy: false, // errors out in electron

--- a/src/public/app/widgets/search_options/ancestor.js
+++ b/src/public/app/widgets/search_options/ancestor.js
@@ -13,7 +13,7 @@ const TPL = `
             <div style="margin-left: 10px; margin-right: 10px">depth:</div>
             
             <select name="depth" class="form-control d-inline ancestor-depth" style="flex-shrink: 3">
-                <option value="">doesn't mattter</option>
+                <option value="">doesn't matter</option>
                 <option value="eq1">is exactly 1 (direct children)</option>
                 <option value="eq2">is exactly 2</option>
                 <option value="eq3">is exactly 3</option>


### PR DESCRIPTION
Fixes #3071

With regards to 
>I think it should be enabled for "server" setup only

: I am unable to run a desktop build for some odd reason (npm build related) so this middleware might be added to the desktop app as well. If there's a better place to add this middleware that would ensure it works on server-only mode I'm open to changes 