### PR TITLE
Add search result count to search page

### DIFF
--- a/src/public/app/services/note_list_renderer.js
+++ b/src/public/app/services/note_list_renderer.js
@@ -147,7 +147,7 @@ class NoteListRenderer {
     /*
      * We're using noteIds so that it's not necessary to load all notes at once when paging
      */
-    constructor($parent, parentNote, noteIds, showNotePath = false) {
+    constructor($parent, $parentCount, parentNote, noteIds, showNotePath = false) {
         this.$noteList = $(TPL);
 
         // note list must be added to the DOM immediatelly, otherwise some functionality scripting (canvas) won't work
@@ -157,6 +157,8 @@ class NoteListRenderer {
         const includedNoteIds = this.getIncludedNoteIds();
 
         this.noteIds = noteIds.filter(noteId => !includedNoteIds.has(noteId) && noteId !== 'hidden');
+
+        $parentCount.append("Count: " + this.noteIds.length);
 
         if (this.noteIds.length === 0) {
             return;

--- a/src/public/app/services/note_list_renderer.js
+++ b/src/public/app/services/note_list_renderer.js
@@ -158,7 +158,7 @@ class NoteListRenderer {
 
         this.noteIds = noteIds.filter(noteId => !includedNoteIds.has(noteId) && noteId !== 'hidden');
 
-        $parentCount.append("Count: " + this.noteIds.length);
+        $parentCount.append("Results: " + this.noteIds.length);
 
         if (this.noteIds.length === 0) {
             return;

--- a/src/public/app/widgets/search_result.js
+++ b/src/public/app/widgets/search_result.js
@@ -30,10 +30,8 @@ const TPL = `
     </div>
     
     <div class="search-result-widget-content-count" style="text-align: center;">
-    
     </div>
     <div class="search-result-widget-content">
-
     </div>
 </div>`;
 

--- a/src/public/app/widgets/search_result.js
+++ b/src/public/app/widgets/search_result.js
@@ -29,7 +29,11 @@ const TPL = `
         Search has not been executed yet. Click on "Search" button above to see the results.
     </div>
     
+    <div class="search-result-widget-content-count" style="text-align: center;">
+    
+    </div>
     <div class="search-result-widget-content">
+
     </div>
 </div>`;
 
@@ -43,16 +47,19 @@ export default class SearchResultWidget extends NoteContextAwareWidget {
         this.$widget = $(TPL);
         this.contentSized();
         this.$content = this.$widget.find('.search-result-widget-content');
+        this.$contentCount = this.$widget.find('.search-result-widget-content-count');
         this.$noResults = this.$widget.find('.search-no-results');
         this.$notExecutedYet = this.$widget.find('.search-not-executed-yet');
     }
 
     async refreshWithNote(note) {
         this.$content.empty();
+        this.$contentCount.empty();
         this.$noResults.toggle(note.getChildNoteIds().length === 0 && !!note.searchResultsLoaded);
+        this.$contentCount.toggle(note.getChildNoteIds().length !== 0 && note.searchResultsLoaded);
         this.$notExecutedYet.toggle(!note.searchResultsLoaded);
 
-        const noteListRenderer = new NoteListRenderer(this.$content, note, note.getChildNoteIds(), true);
+        const noteListRenderer = new NoteListRenderer(this.$content, this.$contentCount, note, note.getChildNoteIds(), true);
         await noteListRenderer.renderList();
     }
 


### PR DESCRIPTION
Fixes #3076 
---
![image](https://user-images.githubusercontent.com/69441971/185770942-2a0b1422-6fe9-4287-b520-435a5ee51fe9.png)


I'm not sure that inlining the CSS is the most ideal way to do it but here's how it looked non-centered: 
![image](https://user-images.githubusercontent.com/69441971/185770886-ea532f95-6b24-43ea-95b4-89c13b2d8a90.png)

Regardless this is just a simple change; the styling is open to changes. 