### PR TITLE
Rate limit the /auth/login route of ETAPI

### DIFF
--- a/src/etapi/auth.js
+++ b/src/etapi/auth.js
@@ -3,8 +3,8 @@ const eu = require("./etapi_utils");
 const passwordEncryptionService = require("../services/password_encryption");
 const etapiTokenService = require("../services/etapi_tokens");
 
-function register(router) {
-    eu.NOT_AUTHENTICATED_ROUTE(router, 'post', '/etapi/auth/login', (req, res, next) => {
+function register(router, loginMiddleware) {
+    eu.NOT_AUTHENTICATED_ROUTE(router, 'post', '/etapi/auth/login', loginMiddleware, (req, res, next) => {
         const {password, tokenName} = req.body;
 
         if (!passwordEncryptionService.verifyPassword(password)) {

--- a/src/etapi/etapi.openapi.yaml
+++ b/src/etapi/etapi.openapi.yaml
@@ -602,6 +602,8 @@ paths:
                   authToken:
                     type: string
                     example: Bc4bFn0Ffiok_4NpbVCDnFz7B2WU+pdhW8B5Ne3DiR5wXrEyqdjgRIsk=
+        '429':
+          description: Client IP has been blacklisted because too many requests (possibly failed authentications) were made within a short time frame, try again later
         default:
           description: unexpected error
           content:

--- a/src/etapi/etapi_utils.js
+++ b/src/etapi/etapi_utils.js
@@ -66,8 +66,8 @@ function route(router, method, path, routeHandler) {
     router[method](path, checkEtapiAuth, (req, res, next) => processRequest(req, res, routeHandler, next, method, path));
 }
 
-function NOT_AUTHENTICATED_ROUTE(router, method, path, routeHandler) {
-    router[method](path, (req, res, next) => processRequest(req, res, routeHandler, next, method, path));
+function NOT_AUTHENTICATED_ROUTE(router, method, path, middleware, routeHandler) {
+    router[method](path, ...middleware, (req, res, next) => processRequest(req, res, routeHandler, next, method, path));
 }
 
 function getAndCheckNote(noteId) {

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -416,7 +416,7 @@ function register(app) {
 
     shareRoutes.register(router);
 
-    etapiAuthRoutes.register(router);
+    etapiAuthRoutes.register(router, [loginRateLimiter]);
     etapiAppInfoRoutes.register(router);
     etapiAttributeRoutes.register(router);
     etapiBranchRoutes.register(router);


### PR DESCRIPTION
Hello.
Lately I discovered that while the /login route of the web interface was properly rate limited, the /etapi/auth/login one wasn't.
This makes Trilium particularly vulnerable to bruteforce attacks, as an attacker can carry out them massively just from one single IP to the latter unprotected API.

This commit makes the aforementioned route use the **same** login rate limiter middleware object that the /login route uses, which means that once the rate limiter is triggered on one route it will apply to the other one as well.

When an IP gets rate limited expressjs will reply with the standard "429" which stands for "Too many requests", so I thought it would be cool to mention that in the etapi.openapi.yaml, unfortunately the content type of this HTTP response is "text/html" and I'm not really sure how to handle that.
So I just added the HTTP response code along with a description, I'm not sure whether it's fine like that or I need to specify the content response details. I tried a validator online and it didn't complain. Please check it out.