### PR TITLE
Fix the update to latest version button in the dropdown menu if update checking is disabled

### DIFF
--- a/src/public/app/widgets/buttons/global_menu.js
+++ b/src/public/app/widgets/buttons/global_menu.js
@@ -38,6 +38,10 @@ const TPL = `
             
         pointer-events: none;
     }
+
+    .update-to-latest-version-button {
+        display: none;
+    }
     </style>
 
     <button type="button" data-toggle="dropdown" data-placement="right"


### PR DESCRIPTION
Hello, I've noticed that if update checking is disabled in the settings Trilium still displays the following (look at the bottom of the drop-down list):
![image](https://user-images.githubusercontent.com/66902406/186514214-c693511e-80ed-4038-b0ca-9c8cea9265e6.png)

After investigating further it seems that recent code refactoring made `this.$updateToLatestVersionButton.toggle(latestVersion > glob.triliumVersion);` unreachable in global_menu.js **if** checking for updates is disabled.

On the other hand the update icon withing the button to open the drop-down menu has `display: none` set by default and as a result doesn't require to be toggled off in JS and wasn't affected. (In fact it doesn't appear)

This patch does the same for the button in the drop-down list.