### PR TITLE
Add get note content to ETAPI spec

### DIFF
--- a/src/etapi/etapi.openapi.yaml
+++ b/src/etapi/etapi.openapi.yaml
@@ -228,6 +228,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /notes/{noteId}/content:
+    parameters:
+      - name: noteId
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/EntityId'
+    get:
+      description: Returns note content idenfied by its ID
+      operationId: getNoteContent
+      responses:
+        '200':
+          description: note content response
+          content:
+            text/html:
+              schema:
+                type: string
   /notes/{noteId}/export:
     parameters:
       - name: noteId

--- a/test-etapi/get-note-content.http
+++ b/test-etapi/get-note-content.http
@@ -1,0 +1,25 @@
+POST {{triliumHost}}/etapi/create-note
+Authorization: {{authToken}}
+Content-Type: application/json
+
+{
+  "parentNoteId": "root",
+  "title": "Hello",
+  "type": "text",
+  "content": "Hi there!"
+}
+
+> {%
+    client.global.set("createdNoteId", response.body.note.noteId);
+    client.global.set("createdBranchId", response.body.branch.branchId);
+%}
+
+###
+
+GET {{triliumHost}}/etapi/notes/{{createdNoteId}}/content
+Authorization: {{authToken}}
+
+> {%
+    client.assert(response.status === 200);
+    client.assert(response.body === "<p>Hi there!</p>");
+%}


### PR DESCRIPTION
* add note content to openapi spec file
* add test for get note content api endpoint

Hey all,

I added the /notes/{note_id}/content ETAPI endpoint into the openapi spec in this commit.

I also added some boilerplate under `test-etapi/get-note-content.http` so there's some test coverage for this but I can't find out how to run these tests.

Please excuse me, I'm not used to committing to established projects. If there's something else I need to do in order to get this merged, please let me know.

Regards,
@jph