### PR TITLE
Add another ETAPI method to the api spec file.

### DIFF
--- a/src/etapi/etapi.openapi.yaml
+++ b/src/etapi/etapi.openapi.yaml
@@ -245,6 +245,19 @@ paths:
             text/html:
               schema:
                 type: string
+    put:
+      description: Updates note content idenfied by its ID
+      operationId: putNoteContentById
+      requestBody:
+        description: html content of note
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        '204':
+          description: note content updated
   /notes/{noteId}/export:
     parameters:
       - name: noteId


### PR DESCRIPTION
Hi @zadam,

I've added another method that's present in the API to the API spec file.

There may be more additions like this trickling in as I go - would you prefer me to make an issue and work on a bigger squashed commit with these changes later?

Another thing I'd like your opinion about is if you think it's worth having separate API endpoints for updating things like the note content.

IMO, it would be better to specify the Note schema to have a content property and then have the note patch method receive it as optional, and update if present. If this sounds reasonable to you I'll probably give it a go myself but I'll open an issue for that one instead of just sending PRs

Regards,
@jph