### PR TITLE
let import continue when malformed URLs are encountered

### DIFF
--- a/src/services/import/zip.js
+++ b/src/services/import/zip.js
@@ -292,7 +292,12 @@ async function importZip(taskContext, fileBuffer, importRootNote) {
             content = content.replace(/<\/body>.*<\/html>/gis, "");
 
             content = content.replace(/src="([^"]*)"/g, (match, url) => {
-                url = decodeURIComponent(url);
+                try {
+                    url = decodeURIComponent(url);
+                } catch (e) {
+                    log.error(`Cannot parse image URL '${url}', keeping original (${e}).`);
+                    return `src="${url}"`;
+                }
 
                 if (isUrlAbsolute(url) || url.startsWith("/")) {
                     return match;
@@ -304,7 +309,12 @@ async function importZip(taskContext, fileBuffer, importRootNote) {
             });
 
             content = content.replace(/href="([^"]*)"/g, (match, url) => {
-                url = decodeURIComponent(url);
+                try {
+                    url = decodeURIComponent(url);
+                } catch (e) {
+                    log.error(`Cannot parse link URL '${url}', keeping original (${e}).`);
+                    return `href="${url}"`;
+                }
 
                 if (isUrlAbsolute(url)) {
                     return match;


### PR DESCRIPTION
Hi,

I recently started using Trilium and wanted to import a rather large set of HTML files.

Some of the files contain invalid links (e.g. `http://example.com/${path}`).

In such case, the import gets stuck with the "Import status" dialog not making any progress.
In the server logs, an exception is thrown:
```
URIError: URI malformed
    at decodeURIComponent (<anonymous>)
     at /usr/src/app/src/services/import/zip.js:307:23
     at String.replace (<anonymous>)
     at saveNote (/usr/src/app/src/services/import/zip.js:306:31)
     at /usr/src/app/src/services/import/zip.js:491:13
     at runMicrotasks (<anonymous>)
     at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

Nothing indicates the malformed URL or which file is causing the issue.

This PR keeps invalid URLs in the imported notes (with some logging).
