### PR TITLE
add file properties widget in mobile layout

### DIFF
--- a/src/public/app/layouts/mobile_layout.js
+++ b/src/public/app/layouts/mobile_layout.js
@@ -10,6 +10,7 @@ import ScreenContainer from "../widgets/mobile_widgets/screen_container.js";
 import ScrollingContainer from "../widgets/containers/scrolling_container.js";
 import ProtectedSessionPasswordDialog from "../widgets/dialogs/protected_session_password.js";
 import ConfirmDialog from "../widgets/dialogs/confirm.js";
+import FilePropertiesWidget from "../widgets/ribbon_widgets/file_properties.js";
 
 const MOBILE_CSS = `
 <style>
@@ -128,7 +129,7 @@ export default class MobileLayout {
                         .child(
                             new NoteDetailWidget()
                                 .css('padding', '5px 20px 10px 0')
-                        )
+                        ).child(new FilePropertiesWidget().css('font-size','smaller'))
                 )
             )
             .child(new ProtectedSessionPasswordDialog())


### PR DESCRIPTION
In mobile view, pdf viewer is unusable (height too small). There's no way to show full file on mobile touch screen device.
Adding file properties at the bottom solve this problem and allow to easily update file from mobile device.

![IMG_7F39819923CC-1](https://user-images.githubusercontent.com/2420301/190919484-3249efc9-588d-4f41-9803-2045faef348a.jpeg)

<img width="1466" alt="Capture d’écran, le 2022-09-18 à 12 48 53" src="https://user-images.githubusercontent.com/2420301/190918821-7c59cc9f-23fd-468e-b528-1e6ee2b15713.png">
