### PR TITLE
use same variable as Firefox for scrollbar thumb

### DIFF
--- a/src/public/stylesheets/style.css
+++ b/src/public/stylesheets/style.css
@@ -778,7 +778,7 @@ body {
 ::-webkit-scrollbar-thumb {
     border-radius: 3px;
     border: 1px solid var(--scrollbar-border-color);
-    background-color: var(--main-background-color);
+    background-color: var(--active-item-background-color);
 }
 
 ::-webkit-scrollbar-corner {


### PR DESCRIPTION
Hi,

I noticed that the scrollbar on WebKit browsers is rather hard to see since it's the same color as the text background (and the scrollbar border is very thin). This is especially noticeable with the light theme.

On Firefox, the thumb uses the --active-item-background-color, which makes it much more visible.
I'm not sure if that's intentional for WebKit? I would suggest to also use --active-item-background-color for WebKit, which I think greatly improves user experience by making the scrollbar more visible. Here's a screenshot comparing the existing style (left) with the proposed change (right).

![trilium-scrollbar](https://user-images.githubusercontent.com/105751/191615237-3abc5370-b42b-4b09-ba8a-aba9a1c39f04.png)

