### PR TITLE
Update docker-compose sample to use node user home dir and pull directly from docker hub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,14 @@
 version: '2.1'
 services:
   trilium:
-    build:
-      context: .
     image: zadam/trilium
     restart: always
     environment:
-      - TRILIUM_DATA_DIR=/data
+      - TRILIUM_DATA_DIR=/home/node/trilium-data
     ports:
       - "8080:8080"
     volumes:
-      - trilium:/data
+      - trilium:/home/node/trilium-data
 
 volumes:
   trilium:
-


### PR DESCRIPTION
In 4fd9e7f user is changed to `node`. Storing data in `/data` caused permissions errors as it is owned by root.  Changing the `TRILIUM_DATA_DIR` to be based on the `node` user's home directory seems to resolve this error.

Removing build context lets it pull directly from docker hub the first time without error.