### PR TITLE
Check both http and https in DockerHealthcheck

### DIFF
--- a/DockerHealthcheck.sh
+++ b/DockerHealthcheck.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
-if wget --spider -S "127.0.0.1:8080/api/health-check" 2>&1 | awk 'NR==2' | grep -w "HTTP/1.1 200 OK" ; then
-    exit 0
-else
-    exit 1
-fi
+
+# Try connecting to /api/health-check using both http and https.
+# TODO: we should only be connecting with the actual protocol that is enabled
+# TODO: this assumes we use the default port 8080
+
+for proto in http https; do
+    if wget --spider -S "$proto://127.0.0.1:8080/api/health-check" 2>&1 | awk 'NR==2' | grep -w "HTTP/1.1 200 OK" ; then
+        exit 0
+    fi
+done
+
+exit 1


### PR DESCRIPTION
I've been getting Docker reporting my Trilium container as unhealthy because wget was trying to talk HTTP to it while it was expecting HTTPS.