### PR TITLE
Allow Mac users to close and re-open window

### DIFF
--- a/electron.js
+++ b/electron.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {app, globalShortcut} = require('electron');
+const {app, globalShortcut, BrowserWindow} = require('electron');
 const sqlInit = require('./src/services/sql_init');
 const appIconService = require('./src/services/app_icon');
 const windowService = require('./src/services/window');
@@ -31,6 +31,14 @@ app.on('ready', async () => {
         await sqlInit.dbReady;
 
         await windowService.createMainWindow(app);
+
+        if (process.platform === 'darwin') {
+            app.on('activate', async () => {
+                if (BrowserWindow.getAllWindows().length === 0) {
+                    await windowService.createMainWindow(app);
+                }
+            });
+        }
 
         tray.createTray();
     }


### PR DESCRIPTION
When a Mac user closes the active window, it doesn't close the app entirely. Unfortunately, this means that once you close the window you cannot re-open it without quitting the app entirely (right click icon -> Quit). Electron suggests checking when the app is activated to see if any windows are open and, if none, create the main window again. I understand that you don't support Mac and have nothing to test on, so I made sure this change only executes on Mac. Hope that's enough.

Also, if it's not safe to run `createMainWindow` a second time, I welcome edits/suggestions on how to fix it.

https://www.electronjs.org/docs/latest/tutorial/quick-start#open-a-window-if-none-are-open-macos

Tested by running `./bin/build-mac-x64.sh` and executing the resulting binary.