### PR TITLE
Filter "Edited notes" when hoisted or in a workspace

### DIFF
--- a/src/routes/api/note_revisions.js
+++ b/src/routes/api/note_revisions.js
@@ -5,6 +5,7 @@ const protectedSessionService = require('../../services/protected_session');
 const noteRevisionService = require('../../services/note_revisions');
 const utils = require('../../services/utils');
 const sql = require('../../services/sql');
+const cls = require('../../services/cls');
 const path = require('path');
 const becca = require("../../becca/becca");
 
@@ -124,8 +125,15 @@ function getEditedNotesOnDate(req) {
         ORDER BY isDeleted
         LIMIT 50`, {date: req.params.date + '%'});
 
-    const notes = becca.getNotes(noteIds, true)
-        .map(note => note.getPojo());
+    let notes = becca.getNotes(noteIds, true);
+
+    // Narrow down the results if a note is hoisted, similar to "Jump to note".
+    const hoistedNoteId = cls.getHoistedNoteId();
+    if (hoistedNoteId) {
+        notes = notes.filter(note => note.hasAncestor(hoistedNoteId));
+    }
+
+    notes = notes.map(note => note.getPojo());
 
     for (const note of notes) {
         const notePath = note.isDeleted ? null : beccaService.getNotePath(note.noteId);


### PR DESCRIPTION
## Summary

The “Edited Notes” tab appears on day notes, showing which notes were edited in that particular day. However, after the introduction of workspace calendar roots, “Edited notes” does not filter out notes which are outside the workspace.

Initially I wanted to implement the filtering by workspace, but soon realised it's not the best idea as it would introduce a completely new filtering system. A better idea was to simply filter out any edited notes which are not part of the hoisted note. If the user does not have any hoisted notes, the existing behaviour is maintained.

This aligns the behaviour of “Edited Notes” to match the one of “Jump to note” or full-text search.

## Rationale

I would personally find this feature useful because I use two workspace calendars: a personal one and a work one. When I'm at work and presenting my daily notes to one of my colleagues, I would not want my personal edited notes to show up.

## Implementation

The backend API to obtain edited notes is modified in order to take into consideration the hoisted note. The note is filtered via .filter instead of altering the SQL call, as it was easier to implement it in JS. 

The performance impact is supposed to be zero when there is no hoisted note (no loop is performed). When there is a hoisted note, the time cost is linear as another loop is introduced. However, in practice the time cost should be minimal considering that the amount of edited notes per day should not be that high for normal usage of the application.

## Testing

Attached an example structure where the behaviour can be tested, with two workspaces (each with a calendar root), and a global calendar root. There are also some manual testing instructions in there.

[Filter Edited notes when hoisted or in a workspace.zip](https://github.com/zadam/trilium/files/9932079/Filter.Edited.notes.when.hoisted.or.in.a.workspace.zip)
