### PR TITLE
Fix missing webpack bundle generation in Docker container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM node:16.18.0-alpine
 # Create app directory
 WORKDIR /usr/src/app
 
+# Bundle app source
+COPY . .
+
 COPY server-package.json package.json
 
 # Install app dependencies
@@ -18,19 +21,18 @@ RUN set -x \
         nasm \
         libpng-dev \
         python3 \
-    && npm install --production \
-    && apk del .build-dependencies
+    && npm install \
+    && apk del .build-dependencies \
+    && npm run webpack \
+    && npm prune --omit=dev \
+# Set the path to the newly created webpack bundle
+    && sed -i -e 's/app\/desktop.js/app-dist\/desktop.js/g' src/views/desktop.ejs \
+    && sed -i -e 's/app\/mobile.js/app-dist\/mobile.js/g' src/views/mobile.ejs \
+    && sed -i -e 's/app\/setup.js/app-dist\/setup.js/g' src/views/setup.ejs \
+    && sed -i -e 's/app\/share.js/app-dist\/share.js/g' src/views/share/*.ejs
 
 # Some setup tools need to be kept
 RUN apk add --no-cache su-exec shadow
-
-# Bundle app source
-COPY . .
-
-RUN sed -i -e 's/app\/desktop.js/app-dist\/desktop.js/g' src/views/desktop.ejs && \
-    sed -i -e 's/app\/mobile.js/app-dist\/mobile.js/g' src/views/mobile.ejs && \
-    sed -i -e 's/app\/setup.js/app-dist\/setup.js/g' src/views/setup.ejs && \
-    sed -i -e 's/app\/share.js/app-dist\/share.js/g' src/views/share/*.ejs
 
 # Add application user and setup proper volume permissions
 RUN adduser -s /bin/false node; exit 0


### PR DESCRIPTION
Some recent commit fixed missing webpack delivery in the Docker images, however the Dockerfile wasn't updated to generate the webpack bundle aswell and as a result no bundle could be found and shipped by Express.

Should fix: #3370 #3372 #3369 