### PR TITLE
Fix powershell exec policy

### DIFF
--- a/bin/build-win-x64.sh
+++ b/bin/build-win-x64.sh
@@ -30,7 +30,7 @@ cp bin/tpl/anonymize-database.sql $BUILD_DIR/
 cp -r dump-db $BUILD_DIR/
 rm -rf $BUILD_DIR/dump-db/node_modules
 
-cp bin/tpl/trilium-{portable,no-cert-check,safe-mode}.{bat,ps1} $BUILD_DIR/
+cp bin/tpl/trilium-{portable,no-cert-check,safe-mode}.bat $BUILD_DIR/
 
 echo "Zipping windows x64 electron distribution..."
 VERSION=`jq -r ".version" package.json`

--- a/bin/tpl/trilium-no-cert-check.bat
+++ b/bin/tpl/trilium-no-cert-check.bat
@@ -1,5 +1,23 @@
+@echo off
+:: Try to get powershell to launch Trilium since it deals with UTF-8 characters in current path
+:: If there's no powershell available, fallback to unicode enabled command interpreter
+
+WHERE powershell.exe > NUL 2>&1
+IF %ERRORLEVEL% NEQ 0 GOTO BATCH ELSE GOTO POWERSHELL
+
+:POWERSHELL
+powershell -ExecutionPolicy Bypass -NonInteractive -NoLogo "Set-Item -Path Env:NODE_TLS_REJECT_UNAUTHORIZED -Value 0; ./trilium.exe"
+GOTO END
+
+:BATCH
+:: Make sure we support UTF-8 characters
+chcp 65001
+
+:: Get Current Trilium executable directory and compute data directory
 SET DIR=%~dp0
 set NODE_TLS_REJECT_UNAUTHORIZED=0
 cd %DIR%
-WHERE powershell.exe
-IF %ERRORLEVEL% NEQ 0 (start trilium.exe) ELSE (powershell.exe ./trilium-no-cert-check.ps1)
+start trilium.exe
+GOTO END
+
+:END

--- a/bin/tpl/trilium-no-cert-check.ps1
+++ b/bin/tpl/trilium-no-cert-check.ps1
@@ -1,2 +1,0 @@
-Set-Item -Path Env:NODE_TLS_REJECT_UNAUTHORIZED -Value 0
-./trilium.exe

--- a/bin/tpl/trilium-portable.bat
+++ b/bin/tpl/trilium-portable.bat
@@ -1,5 +1,23 @@
+@echo off
+:: Try to get powershell to launch Trilium since it deals with UTF-8 characters in current path
+:: If there's no powershell available, fallback to unicode enabled command interpreter
+
+WHERE powershell.exe > NUL 2>&1
+IF %ERRORLEVEL% NEQ 0 GOTO BATCH ELSE GOTO POWERSHELL
+
+:POWERSHELL
+powershell -ExecutionPolicy Bypass -NonInteractive -NoLogo "Set-Item -Path Env:TRILIUM_DATA_DIR -Value './trilium-data'; ./trilium.exe"
+GOTO END
+
+:BATCH
+:: Make sure we support UTF-8 characters
+chcp 65001
+
+:: Get Current Trilium executable directory and compute data directory
 SET DIR=%~dp0
 SET TRILIUM_DATA_DIR=%DIR%\trilium-data
 cd %DIR%
-WHERE powershell.exe
-IF %ERRORLEVEL% NEQ 0 (start trilium.exe) ELSE (powershell.exe ./trilium-portable.ps1)
+start trilium.exe
+GOTO END
+
+:END

--- a/bin/tpl/trilium-portable.ps1
+++ b/bin/tpl/trilium-portable.ps1
@@ -1,2 +1,0 @@
-Set-Item -Path Env:TRILIUM_DATA_DIR -Value './trilium-data'
-./trilium.exe

--- a/bin/tpl/trilium-safe-mode.bat
+++ b/bin/tpl/trilium-safe-mode.bat
@@ -1,5 +1,23 @@
+@echo off
+:: Try to get powershell to launch Trilium since it deals with UTF-8 characters in current path
+:: If there's no powershell available, fallback to unicode enabled command interpreter
+
+WHERE powershell.exe > NUL 2>&1
+IF %ERRORLEVEL% NEQ 0 GOTO BATCH ELSE GOTO POWERSHELL
+
+:POWERSHELL
+powershell -ExecutionPolicy Bypass -NonInteractive -NoLogo "Set-Item -Path Env:TRILIUM_SAFE_MODE -Value 1; ./trilium.exe --disable-gpu"
+GOTO END
+
+:BATCH
+:: Make sure we support UTF-8 characters
+chcp 65001
+
+:: Get Current Trilium executable directory and compute data directory
 SET DIR=%~dp0
 SET TRILIUM_SAFE_MODE=1
 cd %DIR%
-WHERE powershell.exe
-IF %ERRORLEVEL% NEQ 0 (start trilium.exe --disable-gpu) ELSE (powershell.exe ./trilium-safe-mode.ps1)
+start trilium.exe --disable-gpu
+GOTO END
+
+:END

--- a/bin/tpl/trilium-safe-mode.ps1
+++ b/bin/tpl/trilium-safe-mode.ps1
@@ -1,2 +1,0 @@
-Set-Item -Path Env:TRILIUM_SAFE_MODE -Value 1
-./trilium.exe --disable-gpu


### PR DESCRIPTION
Since Powershell won't allow script execution by default, let's inline Powershell commands with specified ExecutionPolicy.
Also, make command interpreter unicode aware using `chcp 65001` when Powershell is not available

Fixes https://github.com/zadam/trilium/issues/3398
Also updates https://github.com/zadam/trilium/issues/2327