### PR TITLE
Fix missing share.js in public/app-dist folder; Delete unused public/app folder (Docker build)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,9 @@ RUN set -x \
     && sed -i -e 's/app\/desktop.js/app-dist\/desktop.js/g' src/views/desktop.ejs \
     && sed -i -e 's/app\/mobile.js/app-dist\/mobile.js/g' src/views/mobile.ejs \
     && sed -i -e 's/app\/setup.js/app-dist\/setup.js/g' src/views/setup.ejs \
-    && sed -i -e 's/app\/share.js/app-dist\/share.js/g' src/views/share/*.ejs
+    && sed -i -e 's/app\/share.js/app-dist\/share.js/g' src/views/share/*.ejs \
+    && cp src/public/app/share.js src/public/app-dist/. \
+    && rm -rf src/public/app
 
 # Some setup tools need to be kept
 RUN apk add --no-cache su-exec shadow


### PR DESCRIPTION
Hi, when I enabled the webpack bundle generation in the Docker build I wrongly assumed that share.js would have been bundled as well, well, it's not the case. Looking at copy-trilium.sh it seems like the file is just 'manually' copied to app-dist and then the app folder is wiped.
This PR introduces the same behavior as the copy-trilium.sh script in the Dockerfile.
Should fix: #3409

(Little side-note: Ultimately I think the Docker build should run the same scripts in the bin/ folder to generate Trilium's server edition, instead of replicating the same behavior manually in the Dockerfile which is easily error-prone... This would probably avoid more annoyances like the one this PR solves in the future.) 