### PR TITLE
Fix clipping selection can create multiple notes for the same Url

### DIFF
--- a/src/routes/api/clipper.js
+++ b/src/routes/api/clipper.js
@@ -14,8 +14,8 @@ const Attribute = require('../../becca/entities/attribute');
 const htmlSanitizer = require('../../services/html_sanitizer');
 const {formatAttrForSearch} = require("../../services/attribute_formatter");
 
-function findClippingNote(todayNote, pageUrl) {
-    const notes = todayNote.searchNotesInSubtree(
+function findClippingNote(clipperInboxNote, pageUrl) {
+    const notes = clipperInboxNote.searchNotesInSubtree(
         formatAttrForSearch({
             type: 'label',
             name: "pageUrl",

--- a/src/routes/api/clipper.js
+++ b/src/routes/api/clipper.js
@@ -47,6 +47,7 @@ function addClipping(req) {
 
     const clipperInbox = getClipperInboxNote();
 
+    pageUrl = htmlSanitizer.sanitize(pageUrl);
     let clippingNote = findClippingNote(clipperInbox, pageUrl);
 
     if (!clippingNote) {
@@ -56,8 +57,6 @@ function addClipping(req) {
             content: '',
             type: 'text'
         }).note;
-
-        pageUrl = htmlSanitizer.sanitize(pageUrl);
 
         clippingNote.setLabel('clipType', 'clippings');
         clippingNote.setLabel('pageUrl', pageUrl);


### PR DESCRIPTION
Hi Zadam

This fixes a bug when you make multiple clippings on the page containing '&' char in url query string.
Fix just calls html_sanitizer.sanitize earlier (before finding clipping note)



