### PR TITLE
Fix pageUrl and clipping selection can create multiple notes for the same Url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@braintree/sanitize-url": "^6.0.2",
         "@electron/remote": "2.0.9",
         "@excalidraw/excalidraw": "0.13.0",
         "archiver": "5.3.1",
@@ -114,6 +115,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz",
+      "integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg=="
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -10551,6 +10557,11 @@
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
+    },
+    "@braintree/sanitize-url": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz",
+      "integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg=="
     },
     "@develar/schema-utils": {
       "version": "2.6.5",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "postinstall": "rimraf ./node_modules/canvas"
   },
   "dependencies": {
+    "@braintree/sanitize-url": "^6.0.2",
     "@electron/remote": "2.0.9",
     "@excalidraw/excalidraw": "0.13.0",
     "archiver": "5.3.1",

--- a/src/routes/api/clipper.js
+++ b/src/routes/api/clipper.js
@@ -14,8 +14,8 @@ const Attribute = require('../../becca/entities/attribute');
 const htmlSanitizer = require('../../services/html_sanitizer');
 const {formatAttrForSearch} = require("../../services/attribute_formatter");
 
-function findClippingNote(todayNote, pageUrl) {
-    const notes = todayNote.searchNotesInSubtree(
+function findClippingNote(clipperInboxNote, pageUrl) {
+    const notes = clipperInboxNote.searchNotesInSubtree(
         formatAttrForSearch({
             type: 'label',
             name: "pageUrl",

--- a/src/routes/api/clipper.js
+++ b/src/routes/api/clipper.js
@@ -47,6 +47,7 @@ function addClipping(req) {
 
     const clipperInbox = getClipperInboxNote();
 
+    pageUrl = htmlSanitizer.sanitizeUrl(pageUrl);
     let clippingNote = findClippingNote(clipperInbox, pageUrl);
 
     if (!clippingNote) {
@@ -56,8 +57,6 @@ function addClipping(req) {
             content: '',
             type: 'text'
         }).note;
-
-        pageUrl = htmlSanitizer.sanitize(pageUrl);
 
         clippingNote.setLabel('clipType', 'clippings');
         clippingNote.setLabel('pageUrl', pageUrl);
@@ -96,7 +95,7 @@ function createNote(req) {
     note.setLabel('clipType', clipType);
 
     if (pageUrl) {
-        pageUrl = htmlSanitizer.sanitize(pageUrl);
+        pageUrl = htmlSanitizer.sanitizeUrl(pageUrl);
 
         note.setLabel('pageUrl', pageUrl);
         note.setLabel('iconClass', 'bx bx-globe');

--- a/src/services/html_sanitizer.js
+++ b/src/services/html_sanitizer.js
@@ -1,4 +1,5 @@
 const sanitizeHtml = require('sanitize-html');
+const sanitizeUrl = require('@braintree/sanitize-url').sanitizeUrl;
 
 // intended mainly as protection against XSS via import
 // secondarily it (partly) protects against "CSS takeover"
@@ -48,5 +49,6 @@ function sanitize(dirtyHtml) {
 }
 
 module.exports = {
-    sanitize
+    sanitize,
+    sanitizeUrl
 };


### PR DESCRIPTION
This is (more correct) alternative of https://github.com/zadam/trilium/pull/3479 - it uses sanitize-url (intead not sanitize-html) for pageUrl)

But it requires additional npm package.