### PR TITLE
Safe Vs Code debug launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
                 "<node_internals>/**"
             ],
             "env": {
-                "TRILIUM_ENV": "dev"
+                "TRILIUM_ENV": "dev",
+                "TRILIUM_DATA_DIR": "./data"
             },
             "outputCapture": "std",
             "program": "${workspaceFolder}/src/www"


### PR DESCRIPTION
vscode launch can break release app data, because it uses default data dir.

I got this problem by pressing F5 in vscode, then db migration started, then it couldn't work because of version conflicts in cluster. Electron app couldn't sync to server anymore, creating endless syncing with errors in log like here https://github.com/zadam/trilium/issues/1163