### PR TITLE
use api.showMessage instead of alert

### DIFF
--- a/src/public/app/doc_notes/launchbar_script_launcher.html
+++ b/src/public/app/doc_notes/launchbar_script_launcher.html
@@ -8,5 +8,5 @@
 <h4>Example script</h4>
 
 <pre>
-alert("Current note is " + api.getActiveContextNote().title);
+api.showMessage("Current note is " + api.getActiveContextNote().title);
 </pre>


### PR DESCRIPTION
To mitigate the issue https://github.com/zadam/trilium/issues/3483, I suggest we use api.showMessage instead of alert in the example code.
