### PR TITLE
Add #calendarType attribute to support monthly or weekly notes

### DIFF
--- a/src/services/date_notes.js
+++ b/src/services/date_notes.js
@@ -64,6 +64,7 @@ function getRootCalendarNote() {
 }
 
 function getParentNote(label, dateStr, rootNote) {
+    console.log('getParentNote', label, dateStr);
     const type = rootNote.getOwnedLabelValue("calendarType") || "monthly";
     if (type != "monthly" && type != "weekly") {
         throw new Error('#calendarType should be "monthly" or "weekly"');
@@ -291,6 +292,7 @@ function getWeekNote(dateStr, options = {}, rootNote = null) {
         new SearchContext({ancestorNoteId: rootNote.noteId}));
 
     if (weekNote) {
+        console.log('getWeekNote: find weekNote');
         // Check whether its year note is right, if not, clone this parentNote
         const yearNotes = weekNote.getParentNotes();
         if (!yearNotes) {
@@ -302,11 +304,18 @@ function getWeekNote(dateStr, options = {}, rootNote = null) {
                 return weekNote;
             }
         }
+        // wrong year
+        console.log('getWeekNote: not year');
         const parentNote = getParentNote("week", dateStr, rootNote);
         if (!parentNote) {
             throw new Error(`Can't find weekly parent note of date "${dateStr}"`);
         }
-        weekNote.cloneTo(parentNote.noteId);
+        console.log('getWeekNote: clone');
+        const status = weekNote.cloneTo(parentNote.noteId);
+        if (!status.success) {
+            throw new Error(`Failed to clone weekly note of date "${dateStr}": ${status.message}`);
+        }
+        console.log('getWeekNote: return');
         return weekNote;
     }
 

--- a/src/services/date_notes.js
+++ b/src/services/date_notes.js
@@ -14,6 +14,7 @@ const hoistedNoteService = require("./hoisted_note");
 const CALENDAR_ROOT_LABEL = 'calendarRoot';
 const YEAR_LABEL = 'yearNote';
 const MONTH_LABEL = 'monthNote';
+const WEEK_LABEL = 'weekNote';
 const DATE_LABEL = 'dateNote';
 
 const DAYS = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
@@ -62,6 +63,166 @@ function getRootCalendarNote() {
     return rootNote;
 }
 
+function getParentNote(label, dateStr, rootNote) {
+    const pattern = rootNote.getOwnedLabelValue("calendarPattern") || "year/month/day";
+    const labels = pattern.split("/")
+
+    {
+        let labelSet = new Set();
+        for (const label of labels) {
+            if (labelSet.has(label)) {
+                throw new Error(`"${label}" in #calendarPattern must be at most one`);
+            }
+            if (label != 'day' && label != 'week' && label != 'month' && label != 'year') {
+                throw new Error(`"${label}" in #calendarPattern should be one of "day", "week", "month" or "year"`)
+            }
+            labelSet.add(label);
+        }
+        if (!labelSet.has('day')) {
+            throw new Error('#calendarPattern must have "day"');
+        }
+    }
+
+    let parentLabel = "root";
+    for (const currLabel of pattern.split("/")) {
+        if (currLabel === label) {
+            break;
+        }
+        parentLabel = currLabel;
+    }
+    switch (parentLabel) {
+        case "root":
+            return rootNote;
+        case "year":
+            return getYearNote(dateStr, rootNote);
+        case "month":
+            return getMonthNote(dateStr, rootNote);
+        case "week":
+            return getWeekNote(dateStr, rootNote);
+        case "day":
+            return getDayNote(dateStr, rootNote);
+    }
+    return null;
+}
+
+function getNoteTitle(pattern, dateStr, options = {}) {
+    const dateObj = dateUtils.parseLocalDate(dateStr);
+    const weekDay = DAYS[dateObj.getDay()];
+    const startOfTheWeek = options.startOfTheWeek || "monday";
+    return pattern.replace(/{(\w+)}/g, function(_, match) {
+        switch(match) {
+            case 'year':
+                console.log('year!!!!!', dateStr.substr(0, 4));
+                return dateStr.substr(0, 4);
+            case 'month':
+                return MONTHS[dateObj.getMonth()];
+            case "monthNumberPadded":
+                return dateStr.substr(5, 2);
+            case "weekNumber":
+                return dateUtils.getWeek(dateObj, startOfTheWeek);
+            case "weekNumberPadded":
+            {
+                let weekNum = dateUtils.getWeek(dateObj, startOfTheWeek);
+                if (weekNum <= 9)
+                    return "0" + weekNum;
+                return weekNum;
+            }
+            case "weekDay":
+                return weekDay;
+            case "weekDay3":
+                return weekDay.substr(0, 3);
+            case "weekDay2":
+                return weekDay.substr(0, 2);
+            case "dayInMonthPadded":
+                return dateStr.substr(8, 2);
+            case "isoDate":
+                return dateUtils.utcDateStr(dateObj);
+            default:
+                throw new Error(`unknown pattern {${match}}`);
+        }
+    });
+}
+
+function getParentNote(label, dateStr, rootNote) {
+    const pattern = rootNote.getOwnedLabelValue("calendarPattern") || "year/month/day";
+    const labels = pattern.split("/")
+
+    {
+        let labelSet = new Set();
+        for (const label of labels) {
+            if (labelSet.has(label)) {
+                throw new Error(`"${label}" in #calendarPattern must be at most one`);
+            }
+            if (label != 'day' && label != 'week' && label != 'month' && label != 'year') {
+                throw new Error(`"${label}" in #calendarPattern should be one of "day", "week", "month" or "year"`)
+            }
+            labelSet.add(label);
+        }
+        if (!labelSet.has('day')) {
+            throw new Error('#calendarPattern must have "day"');
+        }
+    }
+
+    let parentLabel = "root";
+    for (const currLabel of pattern.split("/")) {
+        if (currLabel === label) {
+            break;
+        }
+        parentLabel = currLabel;
+    }
+    switch (parentLabel) {
+        case "root":
+            return rootNote;
+        case "year":
+            return getYearNote(dateStr, rootNote);
+        case "month":
+            return getMonthNote(dateStr, rootNote);
+        case "week":
+            return getWeekNote(dateStr, rootNote);
+        case "day":
+            return getDayNote(dateStr, rootNote);
+    }
+    return null;
+}
+
+function getNoteTitle(pattern, dateStr, options = {}) {
+    const dateObj = dateUtils.parseLocalDate(dateStr);
+    const weekDay = DAYS[dateObj.getDay()];
+    const startOfTheWeek = options.startOfTheWeek || "monday";
+    return pattern.replace(/{(\w+)}/g, function(_, match) {
+        switch(match) {
+            case 'year':
+                console.log('year!!!!!', dateStr.substr(0, 4));
+                return dateStr.substr(0, 4);
+            case 'month':
+                return MONTHS[dateObj.getMonth()];
+            case "monthNumberPadded":
+                return dateStr.substr(5, 2);
+            case "weekNumber":
+                return dateUtils.getWeek(dateObj, startOfTheWeek);
+            case "weekNumberPadded":
+            {
+                let weekNum = dateUtils.getWeek(dateObj, startOfTheWeek);
+                if (weekNum <= 9)
+                    return "0" + weekNum;
+                return weekNum;
+            }
+            case "weekDay":
+                return weekDay;
+            case "weekDay3":
+                return weekDay.substr(0, 3);
+            case "weekDay2":
+                return weekDay.substr(0, 2);
+            case "dayInMonthPadded":
+                return dateStr.substr(8, 2);
+            case "isoDate":
+                return dateUtils.utcDateStr(dateObj);
+            default:
+                throw new Error(`unknown pattern {${match}}`);
+        }
+    });
+}
+
 /** @returns {BNote} */
 function getYearNote(dateStr, rootNote = null) {
     if (!rootNote) {
@@ -77,8 +238,16 @@ function getYearNote(dateStr, rootNote = null) {
         return yearNote;
     }
 
+    const pattern = rootNote.getOwnedLabelValue("yearPattern") || "{year}";
+    const noteTitle = getNoteTitle(pattern, dateStr);
+    const parentNote = getParentNote("year", dateStr, rootNote);
+    if (!parentNote) {
+        let dateObj = dateUtils.parseLocalDate(dateStr);
+        return getDayNote(dateUtils.utcDateTimeStr(dateObj.setMonth(0).setDate(1)), rootNote);
+    }
+
     sql.transactional(() => {
-        yearNote = createNote(rootNote, yearStr);
+        yearNote = createNote(parentNote, noteTitle);
 
         attributeService.createLabel(yearNote.noteId, YEAR_LABEL, yearStr);
         attributeService.createLabel(yearNote.noteId, 'sorted');
@@ -91,15 +260,6 @@ function getYearNote(dateStr, rootNote = null) {
     });
 
     return yearNote;
-}
-
-function getMonthNoteTitle(rootNote, monthNumber, dateObj) {
-    const pattern = rootNote.getOwnedLabelValue("monthPattern") || "{monthNumberPadded} - {month}";
-    const monthName = MONTHS[dateObj.getMonth()];
-
-    return pattern
-        .replace(/{monthNumberPadded}/g, monthNumber)
-        .replace(/{month}/g, monthName);
 }
 
 /** @returns {BNote} */
@@ -118,14 +278,16 @@ function getMonthNote(dateStr, rootNote = null) {
         return monthNote;
     }
 
-    const dateObj = dateUtils.parseLocalDate(dateStr);
-
-    const noteTitle = getMonthNoteTitle(rootNote, monthNumber, dateObj);
-
-    const yearNote = getYearNote(dateStr, rootNote);
+    const pattern = rootNote.getOwnedLabelValue("monthPattern") || "{monthNumberPadded} - {month}";
+    const noteTitle = getNoteTitle(pattern, dateStr);
+    const parentNote = getParentNote("month", dateStr, rootNote);
+    if (!parentNote) {
+        let dateObj = dateUtils.parseLocalDate(dateStr);
+        return getDayNote(dateUtils.utcDateTimeStr(dateObj.setDate(1)), rootNote);
+    }
 
     sql.transactional(() => {
-        monthNote = createNote(yearNote, noteTitle);
+        monthNote = createNote(parentNote, noteTitle);
 
         attributeService.createLabel(monthNote.noteId, MONTH_LABEL, monthStr);
         attributeService.createLabel(monthNote.noteId, 'sorted');
@@ -140,17 +302,6 @@ function getMonthNote(dateStr, rootNote = null) {
     return monthNote;
 }
 
-function getDayNoteTitle(rootNote, dayNumber, dateObj) {
-    const pattern = rootNote.getOwnedLabelValue("datePattern") || "{dayInMonthPadded} - {weekDay}";
-    const weekDay = DAYS[dateObj.getDay()];
-
-    return pattern
-        .replace(/{dayInMonthPadded}/g, dayNumber)
-        .replace(/{isoDate}/g, dateUtils.utcDateStr(dateObj))
-        .replace(/{weekDay}/g, weekDay)
-        .replace(/{weekDay3}/g, weekDay.substr(0, 3))
-        .replace(/{weekDay2}/g, weekDay.substr(0, 2));
-}
 
 /** @returns {BNote} */
 function getDayNote(dateStr, rootNote = null) {
@@ -167,15 +318,12 @@ function getDayNote(dateStr, rootNote = null) {
         return dateNote;
     }
 
-    const monthNote = getMonthNote(dateStr, rootNote);
-    const dayNumber = dateStr.substr(8, 2);
-
-    const dateObj = dateUtils.parseLocalDate(dateStr);
-
-    const noteTitle = getDayNoteTitle(rootNote, dayNumber, dateObj);
+    const pattern = rootNote.getOwnedLabelValue("datePattern") || "{dayInMonthPadded} - {weekDay}";
+    const noteTitle = getNoteTitle(pattern, dateStr);
+    const parentNote = getParentNote("day", dateStr, rootNote);
 
     sql.transactional(() => {
-        dateNote = createNote(monthNote, noteTitle);
+        dateNote = createNote(parentNote, noteTitle);
 
         attributeService.createLabel(dateNote.noteId, DATE_LABEL, dateStr.substr(0, 10));
 
@@ -210,14 +358,47 @@ function getStartOfTheWeek(date, startOfTheWeek) {
     return new Date(date.setDate(diff));
 }
 
+/** @returns {BNote} */
 function getWeekNote(dateStr, options = {}, rootNote = null) {
+    if (!rootNote) {
+        rootNote = getRootCalendarNote();
+    }
+
+    const dateObj = dateUtils.parseLocalDate(dateStr);
     const startOfTheWeek = options.startOfTheWeek || "monday";
+    const weekNumber = dateUtils.getWeek(dateObj, startOfTheWeek);
+    const yearStr = dateStr.trim().substr(0, 4);
+    const weekStr = `${yearStr}WW${weekNumber}`;
 
-    const dateObj = getStartOfTheWeek(dateUtils.parseLocalDate(dateStr), startOfTheWeek);
+    let weekNote = searchService.findFirstNoteWithQuery(`#${WEEK_LABEL}="${weekStr}"`,
+        new SearchContext({ancestorNoteId: rootNote.noteId}));
 
-    dateStr = dateUtils.utcDateTimeStr(dateObj);
+    if (weekNote) {
+        return weekNote;
+    }
 
-    return getDayNote(dateStr, rootNote);
+    const pattern = rootNote.getOwnedLabelValue("weekPattern") || "WW{weekNumber}";
+    const noteTitle = getNoteTitle(pattern, dateStr, options);
+    const parentNote = getParentNote("week", dateStr, rootNote);
+    if (!parentNote) {
+        const weekDateObj = getStartOfTheWeek(dateObj, startOfTheWeek);
+        return getDayNote(dateUtils.utcDateTimeStr(weekDateObj), rootNote);
+    }
+
+    sql.transactional(() => {
+        weekNote = createNote(parentNote, noteTitle);
+
+        attributeService.createLabel(weekNote.noteId, WEEK_LABEL, weekStr);
+        attributeService.createLabel(weekNote.noteId, 'sorted');
+
+        const weekTemplateAttr = rootNote.getOwnedAttribute('relation', 'weekTemplate');
+
+        if (weekTemplateAttr) {
+            attributeService.createRelation(weekNote.noteId, 'template', weekTemplateAttr.value);
+        }
+    });
+
+    return weekNote;
 }
 
 module.exports = {

--- a/src/services/date_notes.js
+++ b/src/services/date_notes.js
@@ -306,8 +306,8 @@ function getWeekNote(dateStr, options = {}, rootNote = null) {
         if (!parentNote) {
             throw new Error(`Can't find weekly parent note of date "${dateStr}"`);
         }
-        yearNotes[0].cloneTo(parentNote.noteId);
-        return yearNotes[0];
+        weekNote.cloneTo(parentNote.noteId);
+        return weekNote;
     }
 
     const pattern = rootNote.getOwnedLabelValue("weekPattern") || "WW{weekNumber}";

--- a/src/services/date_notes.js
+++ b/src/services/date_notes.js
@@ -303,7 +303,11 @@ function getWeekNote(dateStr, options = {}, rootNote = null) {
             }
         }
         const parentNote = getParentNote("week", dateStr, rootNote);
-        return yearNotes[0].cloneTo(parentNote.noteId);
+        if (!parentNote) {
+            throw new Error(`Can't find weekly parent note of date "${dateStr}"`);
+        }
+        yearNotes[0].cloneTo(parentNote.noteId);
+        return yearNotes[0];
     }
 
     const pattern = rootNote.getOwnedLabelValue("weekPattern") || "WW{weekNumber}";

--- a/src/services/date_utils.js
+++ b/src/services/date_utils.js
@@ -68,6 +68,43 @@ function getDateTimeForFile() {
     return new Date().toISOString().substr(0, 19).replace(/:/g, '');
 }
 
+/**
+ * Modify from https://stackoverflow.com/a/9047794
+ * Returns the week number for this date
+ */
+function getWeek(date, startOfTheWeek) {
+    let dowOffset;
+    if (startOfTheWeek === 'monday') {
+        dowOffset = 1;
+    }
+    else if (startOfTheWeek === 'sunday') {
+        dowOffset = 0;
+    }
+    else {
+        throw new Error(`Unrecognized start of the week ${startOfTheWeek}`);
+    }
+    const newYear = new Date(date.getFullYear(),0,1);
+    let day = newYear.getDay()-dowOffset; //the day of week the year begins on
+    day = (day >= 0 ? day : day + 7);
+    const daynum = Math.floor((date.getTime()-newYear.getTime()-(date.getTimezoneOffset()-newYear.getTimezoneOffset())*60000)/86400000) + 1;
+    let weeknum;
+    // if the year starts before the middle of a week
+    if (day < 4) {
+        weeknum = Math.floor((daynum+day-1)/7) + 1;
+        if (weeknum > 52) {
+            const nYear = new Date(date.getFullYear() + 1,0,1);
+            let nday = nYear.getDay() - dowOffset;
+            nday = nday >= 0 ? nday : nday + 7;
+            // if the next year starts before the middle of the week, it is week #1 of that year
+            weeknum = nday < 4 ? 1 : 53;
+        }
+    }
+    else {
+        weeknum = Math.floor((daynum+day-1)/7);
+    }
+    return weeknum;
+}
+
 module.exports = {
     utcNowDateTime,
     localNowDateTime,
@@ -77,5 +114,6 @@ module.exports = {
     parseDate,
     parseDateTime,
     parseLocalDate,
-    getDateTimeForFile
+    getDateTimeForFile,
+    getWeek
 };


### PR DESCRIPTION
Add new attribute `#calendarType` on calendar root note, its value can be `monthly`(default) or `weekly`.
If `#calendarType=monthly`, then the calendar tree will be organized as "year/month/day", this is default option just like before;
if `#calendarType=weekly`, then the calendar tree will be organized as "year/week/day".

Beside, year/month/week/day notes have their own title pattern: `yearPattern`(new), `monthPattern`, `weekPattern`(new) and `datePattern`, and they all support these macros:

- `{year}`: "YYYY"
- `{month}`: month name
- `{monthNumberPadded}`: "MM"
- `{weekNumber}`(new): ISO week number
- `{weekNumberPadded}`(new): "WW"
- `{weekDay}`: week name
- `{weekDay2}` the first two characters of week name
- `{weekDay3}`: the first three characters of week name
- `{dayInMonthPadded}`: "DD"
- `{isoDate}`: "YYYY-MM-DD"
(Add custom macros support?)

---

To implement the design of https://github.com/zadam/trilium/issues/3461, I added a new attribute #calendarPattern which can control the note tree of calendar.

The default value of #calendarPattern is "year/month/day", this will keep the default calendar tree like before.

The label in #calendarPattern can be one of "day", "week", "month" or "year", and there must be at least one "day" in it.

Thanks for any suggestions.