### PR TITLE
Centered vertical align does not seem to work on merged table cells

### DIFF
--- a/src/public/stylesheets/print.css
+++ b/src/public/stylesheets/print.css
@@ -13,4 +13,11 @@
     .relation-map-wrapper {
         height: 100vh !important;
     }
+
+    .table thead th,
+    .table td, .table th {
+        /* Fix center vertical alignment of table cells */
+        vertical-align: middle;
+    }
+
 }

--- a/src/public/stylesheets/style.css
+++ b/src/public/stylesheets/style.css
@@ -990,3 +990,9 @@ button.close:hover {
 textarea {
     cursor: auto;
 }
+
+.table thead th,
+.table td, .table th {
+    /* Fix center vertical alignment of table cells */
+    vertical-align: middle;
+}


### PR DESCRIPTION
It appears that the “center” vertical align for cells in tables is not working, as the text is bottom-aligned:

Before:

![image](https://user-images.githubusercontent.com/21236836/221436274-145f0f24-f525-4832-a36e-73c1e7f2e0a1.png)

After:

![image](https://user-images.githubusercontent.com/21236836/221436426-6e1e8efc-0e9b-418e-bf71-0b1d6b266ee1.png)

The fix was to override a style introduced by `bootstrap.min.css` in both the application style, as well as the print style. 

See attached for more information:

https://github.com/zadam/trilium/files/10834709/Centered.vertical.align.does.not.seem.to.work.on.merged.table.cells.pdf