### PR TITLE
Infinite loop when searching for '' in Jump to note

### DIFF
--- a/src/services/search/services/search.js
+++ b/src/services/search/services/search.js
@@ -334,6 +334,11 @@ function highlightSearchResults(searchResults, highlightedTokens) {
     }
 
     for (const token of highlightedTokens) {
+        if (!token) {
+            // Avoid empty tokens, which might cause an infinite loop.
+            continue;
+        }
+
         for (const result of searchResults) {
             // Reset token
             const tokenRegex = new RegExp(utils.escapeRegExp(token), "gi");


### PR DESCRIPTION
By typing two apostrophes (`'`) in “Jump to note”, the server freezes.

Reproduced in both 0.58.8 and latest master branch.

See [Analysis](https://github.com/zadam/trilium/files/10834981/Analysis.pdf).
