### PR TITLE
Allow arbitrary labels to be added via web clipper

### DIFF
--- a/src/routes/api/clipper.js
+++ b/src/routes/api/clipper.js
@@ -75,7 +75,7 @@ function addClipping(req) {
 }
 
 function createNote(req) {
-    let {title, content, pageUrl, images, clipType} = req.body;
+    let {title, content, pageUrl, images, clipType, labels} = req.body;
 
     if (!title || !title.trim()) {
         title = `Clipped note from ${pageUrl}`;
@@ -99,6 +99,13 @@ function createNote(req) {
 
         note.setLabel('pageUrl', pageUrl);
         note.setLabel('iconClass', 'bx bx-globe');
+    }
+    
+    if (labels) {
+        for (const labelName in labels) {
+            console.log('set label ' + labelName + ' on the new note!');
+            note.setLabel(labelName, labels[labelName]);
+        }
     }
 
     const rewrittenContent = processContent(images, note, content);

--- a/src/routes/api/clipper.js
+++ b/src/routes/api/clipper.js
@@ -103,8 +103,8 @@ function createNote(req) {
     
     if (labels) {
         for (const labelName in labels) {
-            console.log('set label ' + labelName + ' on the new note!');
-            note.setLabel(labelName, labels[labelName]);
+            const labelValue = htmlSanitizer.sanitize(labels[labelName]);
+            note.setLabel(labelName, labelValue);
         }
     }
 


### PR DESCRIPTION
This change adds handling of a `labels` property in the json body of `POST /api/clipper/notes` API, the value of the `labels` property is expected to be key/value pairs.