### PR TITLE
“Docker non-root healthcheck”

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ RUN adduser -s /bin/false node; exit 0
 EXPOSE 8080
 CMD [ "./start-docker.sh" ]
 
-HEALTHCHECK --start-period=10s CMD node docker_healthcheck.js
+HEALTHCHECK --start-period=10s CMD exec su-exec node node docker_healthcheck.js


### PR DESCRIPTION
fix the bug "Every day generate a root log?(Bug report)" #3677
by set the healthy check run as user node.