### PR TITLE
Support listening on the unix socket

### DIFF
--- a/docker_healthcheck.js
+++ b/docker_healthcheck.js
@@ -10,16 +10,25 @@ if (config.https) {
 
 const port = require('./src/services/port');
 const host = require('./src/services/host');
-const url = `http://${host}:${port}/api/health-check`;
-const options = { timeout: 2000 };
-const request = http.request(url, options, res => {
+
+let options = {timeout: 2000};
+const callback = res => {
     console.log(`STATUS: ${res.statusCode}`);
     if (res.statusCode === 200) {
         process.exit(0);
     } else {
         process.exit(1);
     }
-});
+};
+let request;
+if (port !== 0) { // TCP socket.
+    const url = `http://${host}:${port}/api/health-check`;
+    request = http.request(url, options, callback);
+} else { // Unix socket.
+    options.socketPath = host;
+    options.path = '/api/health-check';
+    request = http.request(options, callback);
+}
 request.on("error", err => {
     console.log("ERROR");
     process.exit(1);

--- a/src/services/port.js
+++ b/src/services/port.js
@@ -6,7 +6,7 @@ const dataDir = require('./data_dir');
 function parseAndValidate(portStr, source) {
     const portNum = parseInt(portStr);
 
-    if (!portNum || portNum < 0 || portNum >= 65536) {
+    if (!portNum && portNum !== 0 || portNum < 0 || portNum >= 65536) {
         console.log(`FATAL ERROR: Invalid port value "${portStr}" from ${source}, should be a number between 0 and 65536.`);
         process.exit(-1);
     }

--- a/src/www
+++ b/src/www
@@ -100,13 +100,14 @@ async function startTrilium() {
      */
 
     httpServer.keepAliveTimeout = 120000 * 5;
-    if (port !== 0) {
+    const listenTcp = port !== 0;
+    if (listenTcp) {
       httpServer.listen(port, host); // TCP socket.
     } else {
       httpServer.listen(host); // Unix socket.
     }
     httpServer.on('error', error => {
-            if (error.syscall !== 'listen') {
+            if (!listenTcp || error.syscall !== 'listen') {
                 throw error;
             }
 
@@ -128,7 +129,13 @@ async function startTrilium() {
         }
     )
 
-    httpServer.on('listening', () => log.info(`Listening on port ${httpServer.address().port}`));
+    httpServer.on('listening', () => {
+        if (listenTcp) {
+            log.info(`Listening on port ${port}`)
+        } else {
+            log.info(`Listening on unix socket ${host}`)
+        }
+    });
 
     ws.init(httpServer, sessionParser);
 

--- a/src/www
+++ b/src/www
@@ -100,7 +100,11 @@ async function startTrilium() {
      */
 
     httpServer.keepAliveTimeout = 120000 * 5;
-    httpServer.listen(port, host);
+    if (port !== 0) {
+      httpServer.listen(port, host); // TCP socket.
+    } else {
+      httpServer.listen(host); // Unix socket.
+    }
     httpServer.on('error', error => {
             if (error.syscall !== 'listen') {
                 throw error;


### PR DESCRIPTION
Hi, I have added support for Trilium to listen on Unix sockets instead of TCP. This is more convenient for my use case when using Trilium with nginx reverse proxy. Additionally, I have fixed a small bug with the validation of the `portNum` parameter.