### PR TITLE
Add `onenote` Scheme to html sanitizer

### DIFF
--- a/src/services/html_sanitizer.js
+++ b/src/services/html_sanitizer.js
@@ -48,8 +48,8 @@ function sanitize(dirtyHtml) {
         allowedSchemes: [
             'http', 'https', 'ftp', 'ftps', 'mailto', 'data', 'evernote', 'file', 'facetime', 'irc', 'gemini', 'git',
             'gopher', 'imap', 'irc', 'irc6', 'jabber', 'jar', 'lastfm', 'ldap', 'ldaps', 'magnet', 'message',
-            'mumble', 'nfs', 'pop', 'rmi', 's3', 'sftp', 'skype', 'sms', 'spotify', 'steam', 'svn', 'udp', 'view-source',
-            'vnc', 'ws', 'wss', 'xmpp', 'jdbc', 'slack'
+            'mumble', 'nfs', 'onenote', 'pop', 'rmi', 's3', 'sftp', 'skype', 'sms', 'spotify', 'steam', 'svn', 'udp',
+            'view-source', 'vnc', 'ws', 'wss', 'xmpp', 'jdbc', 'slack'
         ],
         transformTags,
     });


### PR DESCRIPTION
Currently when importing from onenote (first imported to evernote, then exported to `.enex`) we loose the onenote internal links which use the `onenote:///` uri scheme
Internal links will obviously not work, but it would sill be nice to preserve the links so that the links can be manually updated to link to internal Trilium pages.