### PR TITLE
Avoid EditableCode inheriting mode from previous notes.

### DIFF
--- a/src/public/app/widgets/type_widgets/editable_code.js
+++ b/src/public/app/widgets/type_widgets/editable_code.js
@@ -77,12 +77,15 @@ export default class EditableCodeTypeWidget extends TypeWidget {
             this.codeEditor.setValue(noteComplement.content || "");
             this.codeEditor.clearHistory();
 
-            const info = CodeMirror.findModeByMIME(note.mime);
-
-            if (info) {
-                this.codeEditor.setOption("mode", info.mime);
-                CodeMirror.autoLoadMode(this.codeEditor, info.mode);
+            let info = CodeMirror.findModeByMIME(note.mime);
+            if (!info) {
+                // Switch back to plain text if CodeMirror does not have a mode for whatever MIME type we're editing.
+                // To avoid inheriting a mode from a previously open code note.
+                info = CodeMirror.findModeByMIME("text/plain");
             }
+
+            this.codeEditor.setOption("mode", info.mime);
+            CodeMirror.autoLoadMode(this.codeEditor, info.mode);
         });
 
         this.show();


### PR DESCRIPTION
Previously, if CodeMirror doesn't support a mode explicitly the mode wouldn't be updated on refresh. This means editors like Mermaid would get their mode "inherited" from the previous mode you had open.

Now the mode is set to text/plain if CodeMirror doesn't support the note's MIME type.

P.S. some of the mermaid diagrams in the demo data have their MIME type incorrectly set to text/plain rather than text/mermaid, so it doesn't reproduce on all diagrams in the demo data.