### PR TITLE
Fix typo in backend API createOrUpdateLauncher()

### DIFF
--- a/src/services/backend_script_api.js
+++ b/src/services/backend_script_api.js
@@ -475,7 +475,7 @@ function BackendScriptApi(currentNote, apiParams) {
         const noteId = 'al_' + opts.id;
 
         const launcherNote =
-            becca.getNote(opts.id) ||
+            becca.getNote(noteId) ||
             specialNotesService.createLauncher({
                 noteId: noteId,
                 parentNoteId: parentNoteId,
@@ -514,7 +514,7 @@ function BackendScriptApi(currentNote, apiParams) {
         if (opts.icon) {
             launcherNote.setLabel('iconClass', `bx ${opts.icon}`);
         } else {
-            launcherNote.removeLabel('keyboardShortcut');
+            launcherNote.removeLabel('iconClass');
         }
 
         return {note: launcherNote};


### PR DESCRIPTION
Fixed two typos in `createOrUpdateLauncher()` of `backend_script_api.js`.

1. **Line 478:** `becca.getNote(opts.id)` should be `becca.getNote(noteId)`

The parameter note ID should include the `"al_"` prefix defined a few lines before, otherwise the API would repeatedly create new launcher notes even when there exists one with matching launcher ID.  

The existing problem is even severer when a particular launcher is to be updated from visible to invisible (or vice versa). Then, the API essentially creates two notes with the same "al_XXXX" ID under the Available Launchers and the Visible Launchers branches.  

2. **Line 517:** `launcherNote.removeLabel('keyboardShortcut');` should be `launcherNote.removeLabel('iconClass');`

For properly updating the launcher icon.