### PR TITLE
Use same margin all around note-book-card

### DIFF
--- a/src/public/app/services/note_list_renderer.js
+++ b/src/public/app/services/note_list_renderer.js
@@ -12,86 +12,86 @@ const TPL = `
         position: relative;
         height: 100%;
     }
-    
+
     .note-list.grid-view .note-list-container {
         display: flex;
         flex-wrap: wrap;
     }
-    
+
     .note-list.grid-view .note-book-card {
         flex-basis: 300px;
         border: 1px solid transparent;
     }
-    
+
     .note-list.grid-view .note-expander {
         display: none;
     }
-    
+
     .note-list.grid-view .note-book-card {
         max-height: 300px;
     }
-    
+
     .note-list.grid-view .note-book-card:hover {
         cursor: pointer;
         border: 1px solid var(--main-border-color);
         background: var(--more-accented-background-color);
     }
-    
+
     .note-book-card {
         border-radius: 10px;
         background-color: var(--accented-background-color);
         padding: 10px 15px 15px 8px;
-        margin: 5px 5px 5px 0;
+        margin: 5px 5px 5px 5px;
         overflow: hidden;
         display: flex;
         flex-direction: column;
         flex-shrink: 0;
         flex-grow: 1;
     }
-    
+
     .note-book-card:not(.expanded) .note-book-content {
         display: none !important;
         padding: 10px
     }
-    
+
     .note-book-card.expanded .note-book-content {
         display: block;
         min-height: 0;
         height: 100%;
         padding-top: 10px;
     }
-    
+
     .note-book-header {
         margin-bottom: 0;
         word-break: break-all;
     }
-    
+
     /* not-expanded title is limited to one line only */
     .note-book-card:not(.expanded) .note-book-header {
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
     }
-    
+
     .note-book-header .rendered-note-attributes {
         font-size: medium;
     }
-    
+
     .note-book-header .rendered-note-attributes:before {
         content: "\\00a0\\00a0";
     }
-    
+
     .note-book-header .note-icon {
         font-size: 100%;
         display: inline-block;
         padding-right: 7px;
         position: relative;
     }
-    
+
     .note-book-card .note-book-card {
         border: 1px solid var(--main-border-color);
     }
-    
+
     .note-book-content.type-image, .note-book-content.type-file, .note-book-content.type-protectedSession {
         display: flex;
         align-items: center;
@@ -99,46 +99,46 @@ const TPL = `
         text-align: center;
         padding: 10px;
     }
-    
+
     .note-book-content.type-image img, .note-book-content.type-canvas svg {
         max-width: 100%;
         max-height: 100%;
         object-fit: contain;
     }
-    
+
     .note-book-card.type-image .note-book-content img,
     .note-book-card.type-text .note-book-content img,
     .note-book-card.type-canvas .note-book-content img {
         max-width: 100%;
         max-height: 100%;
     }
-    
+
     .note-book-header {
         flex-grow: 0;
     }
-    
+
     .note-list-wrapper {
         height: 100%;
         overflow: auto;
     }
-    
+
     .note-expander {
         font-size: x-large;
         position: relative;
         top: 3px;
         cursor: pointer;
     }
-    
+
     .note-list-pager {
         text-align: center;
     }
     </style>
-    
+
     <div class="note-list-wrapper">
         <div class="note-list-pager"></div>
-    
+
         <div class="note-list-container"></div>
-        
+
         <div class="note-list-pager"></div>
     </div>
 </div>`;


### PR DESCRIPTION
There might be a reason why, but the margins between the note-book-cards are not uniform.

Current:
![image](https://user-images.githubusercontent.com/10717998/226731461-f3166ee1-bd09-496f-8762-72c89956fbc0.png)

Adjustment:
![image](https://user-images.githubusercontent.com/10717998/226731533-71cf81f3-6acb-4f03-a9c7-9201ecd18c94.png)
