### PR TITLE
Add bottom border to note-book-header

### DIFF
--- a/src/public/app/services/note_list_renderer.js
+++ b/src/public/app/services/note_list_renderer.js
@@ -62,7 +62,9 @@ const TPL = `
     }
 
     .note-book-header {
+        border-bottom: 1px solid var(--main-border-color);
         margin-bottom: 0;
+        padding-bottom: .5rem;
         word-break: break-all;
     }
 


### PR DESCRIPTION
Potentially fixes #3747 

No Hover:
![image](https://user-images.githubusercontent.com/10717998/227570493-146f604b-34f4-4aae-91f1-4bc5e69deccd.png)

Hover:
![image](https://user-images.githubusercontent.com/10717998/227570523-e2a4fcbe-ef5e-47d5-9e60-3436fd40b71b.png)
