### PR TITLE
fix: disable left click when context menu opening

### DIFF
--- a/src/public/app/menus/context_menu.js
+++ b/src/public/app/menus/context_menu.js
@@ -5,6 +5,8 @@ class ContextMenu {
         this.$widget = $("#context-menu-container");
         this.dateContextMenuOpenedMs = 0;
 
+        this.hideHandlers = [];
+
         $(document).on('click', () => this.hide());
     }
 
@@ -20,6 +22,8 @@ class ContextMenu {
         this.positionMenu();
 
         this.dateContextMenuOpenedMs = Date.now();
+
+        return this;
     }
 
     positionMenu() {
@@ -148,7 +152,21 @@ class ContextMenu {
         // we might filter out right clicks, but then it's better if even right clicks close the context menu
         if (Date.now() - this.dateContextMenuOpenedMs > 300) {
             this.$widget.hide();
+
+            setTimeout(() => {
+                this.hideHandlers.forEach(fn => {
+                    fn(this);
+                });
+            }, 0);
+
         }
+    }
+    onHide(fn) {
+        this.hideHandlers.push(fn);
+        return () => {
+            const fnIndex = this.hideHandlers.findIndex(v => v === fn);
+            this.hideHandlers.splice(fnIndex, 1);
+        };
     }
 }
 

--- a/src/public/app/menus/link_context_menu.js
+++ b/src/public/app/menus/link_context_menu.js
@@ -1,8 +1,8 @@
 import contextMenu from "./context_menu.js";
 import appContext from "../components/app_context.js";
 
-function openContextMenu(notePath, hoistedNoteId, e, callback) {
-    contextMenu.show({
+function openContextMenu(notePath, hoistedNoteId, e) {
+    return contextMenu.show({
         x: e.pageX,
         y: e.pageY,
         items: [
@@ -16,20 +16,19 @@ function openContextMenu(notePath, hoistedNoteId, e, callback) {
             }
 
             if (command === 'openNoteInNewTab') {
-                await appContext.tabManager.openContextWithNote(notePath, {hoistedNoteId});
+                appContext.tabManager.openContextWithNote(notePath, {hoistedNoteId});
             }
             else if (command === 'openNoteInNewSplit') {
                 const subContexts = appContext.tabManager.getActiveContext().getSubContexts();
                 const {ntxId} = subContexts[subContexts.length - 1];
 
-                await appContext.triggerCommand("openNewNoteSplit", {ntxId, notePath, hoistedNoteId});
+                appContext.triggerCommand("openNewNoteSplit", {ntxId, notePath, hoistedNoteId});
             }
             else if (command === 'openNoteInNewWindow') {
-                await appContext.triggerCommand('openInWindow', {notePath, hoistedNoteId});
+                appContext.triggerCommand('openInWindow', {notePath, hoistedNoteId});
             }
-            callback && callback()
         }
-    });
+    })
 }
 
 export default {

--- a/src/public/app/menus/link_context_menu.js
+++ b/src/public/app/menus/link_context_menu.js
@@ -1,7 +1,7 @@
 import contextMenu from "./context_menu.js";
 import appContext from "../components/app_context.js";
 
-function openContextMenu(notePath, hoistedNoteId, e) {
+function openContextMenu(notePath, hoistedNoteId, e, callback) {
     contextMenu.show({
         x: e.pageX,
         y: e.pageY,
@@ -10,23 +10,24 @@ function openContextMenu(notePath, hoistedNoteId, e) {
             {title: "Open note in a new split", command: "openNoteInNewSplit", uiIcon: "bx bx-dock-right"},
             {title: "Open note in a new window", command: "openNoteInNewWindow", uiIcon: "bx bx-window-open"}
         ],
-        selectMenuItemHandler: ({command}) => {
+        selectMenuItemHandler: async ({command}) => {
             if (!hoistedNoteId) {
                 hoistedNoteId = appContext.tabManager.getActiveContext().hoistedNoteId;
             }
 
             if (command === 'openNoteInNewTab') {
-                appContext.tabManager.openContextWithNote(notePath, { hoistedNoteId });
+                await appContext.tabManager.openContextWithNote(notePath, {hoistedNoteId});
             }
             else if (command === 'openNoteInNewSplit') {
                 const subContexts = appContext.tabManager.getActiveContext().getSubContexts();
                 const {ntxId} = subContexts[subContexts.length - 1];
 
-                appContext.triggerCommand("openNewNoteSplit", {ntxId, notePath, hoistedNoteId});
+                await appContext.triggerCommand("openNewNoteSplit", {ntxId, notePath, hoistedNoteId});
             }
             else if (command === 'openNoteInNewWindow') {
-                appContext.triggerCommand('openInWindow', {notePath, hoistedNoteId});
+                await appContext.triggerCommand('openInWindow', {notePath, hoistedNoteId});
             }
+            callback && callback()
         }
     });
 }

--- a/src/public/app/widgets/note_map.js
+++ b/src/public/app/widgets/note_map.js
@@ -120,8 +120,10 @@ export default class NoteMapWidget extends NoteContextAwareWidget {
                 }
             })
             .onNodeRightClick(async (node, e) => {
-                isContextMenuOpening = true
-                linkContextMenuService.openContextMenu(node.id, null, e, () => {isContextMenuOpening = false})
+                isContextMenuOpening = true;
+
+                const contextMenu = await linkContextMenuService.openContextMenu(node.id, null, e);
+                const removeHideHandler = contextMenu.onHide(() => {isContextMenuOpening = false; removeHideHandler()});
             });
 
         if (this.mapType === 'link') {

--- a/src/public/app/widgets/note_map.js
+++ b/src/public/app/widgets/note_map.js
@@ -57,7 +57,7 @@ export default class NoteMapWidget extends NoteContextAwareWidget {
 
         window.addEventListener('resize', () => this.setDimensions(), false);
 
-        this.$widget.find(".map-type-switcher button").on("click",  async e => {
+        this.$widget.find(".map-type-switcher button").on("click", async e => {
             const type = $(e.target).closest("button").attr("data-type");
 
             await attributeService.setLabel(this.noteId, 'mapType', type);
@@ -91,6 +91,8 @@ export default class NoteMapWidget extends NoteContextAwareWidget {
 
         await libraryLoader.requireLibrary(libraryLoader.FORCE_GRAPH);
 
+        let isContextMenuOpening = false
+
         this.graph = ForceGraph()(this.$container[0])
             .width(this.$container.width())
             .height(this.$container.height())
@@ -112,8 +114,15 @@ export default class NoteMapWidget extends NoteContextAwareWidget {
             .linkDirectionalArrowRelPos(1)
             .linkWidth(1)
             .linkColor(() => this.css.mutedTextColor)
-            .onNodeClick(node => appContext.tabManager.getActiveContext().setNote(node.id))
-            .onNodeRightClick((node, e) => linkContextMenuService.openContextMenu(node.id, null, e));
+            .onNodeClick(node => {
+                if (!isContextMenuOpening) {
+                    appContext.tabManager.getActiveContext().setNote(node.id)
+                }
+            })
+            .onNodeRightClick(async (node, e) => {
+                isContextMenuOpening = true
+                linkContextMenuService.openContextMenu(node.id, null, e, () => {isContextMenuOpening = false})
+            });
 
         if (this.mapType === 'link') {
             this.graph


### PR DESCRIPTION
![GIF 2023-4-6 13-08-20](https://user-images.githubusercontent.com/32272399/230277366-b175b0c0-c826-41bc-9dc6-80ee2ed66209.gif)
In desktop setup, the main context note will change following an click of the context menu occasionally, especially in an low-performance compute. You can use a cpu slowdown simulation in performance panel to reproduce it.
It works totally fine on webpage version.
The context menu has stopped propagation, but force-graph plugin still captured the click event. 
Currently an workaround is moving mouse pointer away to stop hovering a note before clicking an context menu item.
This is quite rough solution, just trying to provide some infomation to make trilium better.🙂