### PR TITLE
Perf: add persistent http cache in prod

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -5,12 +5,13 @@ const favicon = require('serve-favicon');
 const cookieParser = require('cookie-parser');
 const helmet = require('helmet');
 const session = require('express-session');
-const compression = require('compression')
+const compression = require('compression');
 const FileStore = require('session-file-store')(session);
 const sessionSecret = require('./services/session_secret');
 const dataDir = require('./services/data_dir');
 const utils = require('./services/utils');
 const assetPath = require('./services/asset_path');
+const env = require('./services/env');
 require('./services/handlers');
 require('./becca/becca_loader');
 
@@ -30,27 +31,37 @@ app.use(helmet({
     crossOriginEmbedderPolicy: false
 }));
 
+const persistentCacheStatic = (root, options) => {
+    if (!env.isDev()) {
+        options = {
+            maxAge: '1y',
+            ...options
+        };
+    }
+    return express.static(root, options);
+};
+
 app.use(express.text({limit: '500mb'}));
 app.use(express.json({limit: '500mb'}));
 app.use(express.raw({limit: '500mb'}));
 app.use(express.urlencoded({extended: false}));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public/root')));
-app.use(`/${assetPath}/app`, express.static(path.join(__dirname, 'public/app')));
-app.use(`/${assetPath}/app-dist`, express.static(path.join(__dirname, 'public/app-dist')));
-app.use(`/${assetPath}/fonts`, express.static(path.join(__dirname, 'public/fonts')));
+app.use(`/${assetPath}/app`, persistentCacheStatic(path.join(__dirname, 'public/app')));
+app.use(`/${assetPath}/app-dist`, persistentCacheStatic(path.join(__dirname, 'public/app-dist')));
+app.use(`/${assetPath}/fonts`, persistentCacheStatic(path.join(__dirname, 'public/fonts')));
 app.use(`/assets/vX/fonts`, express.static(path.join(__dirname, 'public/fonts')));
-app.use(`/${assetPath}/stylesheets`, express.static(path.join(__dirname, 'public/stylesheets')));
+app.use(`/${assetPath}/stylesheets`, persistentCacheStatic(path.join(__dirname, 'public/stylesheets')));
 app.use(`/assets/vX/stylesheets`, express.static(path.join(__dirname, 'public/stylesheets')));
-app.use(`/${assetPath}/libraries`, express.static(path.join(__dirname, '..', 'libraries')));
+app.use(`/${assetPath}/libraries`, persistentCacheStatic(path.join(__dirname, '..', 'libraries')));
 app.use(`/assets/vX/libraries`, express.static(path.join(__dirname, '..', 'libraries')));
 // excalidraw-view mode in shared notes
-app.use(`/${assetPath}/node_modules/react/umd/react.production.min.js`, express.static(path.join(__dirname, '..', 'node_modules/react/umd/react.production.min.js')));
-app.use(`/${assetPath}/node_modules/react-dom/umd/react-dom.production.min.js`, express.static(path.join(__dirname, '..', 'node_modules/react-dom/umd/react-dom.production.min.js')));
+app.use(`/${assetPath}/node_modules/react/umd/react.production.min.js`, persistentCacheStatic(path.join(__dirname, '..', 'node_modules/react/umd/react.production.min.js')));
+app.use(`/${assetPath}/node_modules/react-dom/umd/react-dom.production.min.js`, persistentCacheStatic(path.join(__dirname, '..', 'node_modules/react-dom/umd/react-dom.production.min.js')));
 // expose whole dist folder since complete assets are needed in edit and share
 app.use(`/node_modules/@excalidraw/excalidraw/dist/`, express.static(path.join(__dirname, '..', 'node_modules/@excalidraw/excalidraw/dist/')));
-app.use(`/${assetPath}/node_modules/@excalidraw/excalidraw/dist/`, express.static(path.join(__dirname, '..', 'node_modules/@excalidraw/excalidraw/dist/')));
-app.use(`/${assetPath}/images`, express.static(path.join(__dirname, '..', 'images')));
+app.use(`/${assetPath}/node_modules/@excalidraw/excalidraw/dist/`, persistentCacheStatic(path.join(__dirname, '..', 'node_modules/@excalidraw/excalidraw/dist/')));
+app.use(`/${assetPath}/images`, persistentCacheStatic(path.join(__dirname, '..', 'images')));
 app.use(`/assets/vX/images`, express.static(path.join(__dirname, '..', 'images')));
 app.use(`/manifest.webmanifest`, express.static(path.join(__dirname, 'public/manifest.webmanifest')));
 app.use(`/robots.txt`, express.static(path.join(__dirname, 'public/robots.txt')));
@@ -61,7 +72,7 @@ const sessionParser = session({
     cookie: {
         //    path: "/",
         httpOnly: true,
-        maxAge:  24 * 60 * 60 * 1000 // in milliseconds
+        maxAge: 24 * 60 * 60 * 1000 // in milliseconds
     },
     name: 'trilium.sid',
     store: new FileStore({


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32272399/230607012-6800e245-df65-4b4d-9762-fec679553182.png)
Assets with version path can be cached permanently to improve loading performance. 