### PR TITLE
Activating after removal of subContexts conforms to mainContexts

### DIFF
--- a/src/public/app/components/tab_manager.js
+++ b/src/public/app/components/tab_manager.js
@@ -388,7 +388,12 @@ export default class TabManager extends Component {
             await this.triggerEvent('beforeNoteContextRemove', { ntxIds: ntxIdsToRemove });
 
             if (!noteContextToRemove.isMainContext()) {
-                await this.activateNoteContext(noteContextToRemove.getMainContext().ntxId);
+                const siblings = noteContextToRemove.getMainContext().getSubContexts();
+                const idx = siblings.findIndex(nc => nc.ntxId === noteContextToRemove.ntxId);
+                const contextToActivateIdx = idx === siblings.length - 1 ? idx - 1 : idx + 1;
+                const contextToActivate = siblings[contextToActivateIdx];
+
+                await this.activateNoteContext(contextToActivate.ntxId);
             }
             else if (this.mainNoteContexts.length <= 1) {
                 await this.openAndActivateEmptyTab();


### PR DESCRIPTION
![GIF 2023-4-13 18-57-12](https://user-images.githubusercontent.com/32272399/231738428-6bbe1ef3-999b-4e6d-8ed3-b69cb9ad1511.gif)
Hi. 
In desktop I personally like to use a split to browse my notes and use ctrl+w to close a subContext. The problem to me is that I can't use the shortcut to close subContexts smoothly,and I found by current design, the new context to activate is alway mainContext. 
Generally I think it's more reasonable that subContext's behavior conform to mainContext's, which give us a consistent experience.