### PR TITLE
chore: dev auto reload

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,13 @@
+{
+    "restartable": "rs",
+    "ignore": [".git", "node_modules/**/node_modules", "src/public/"],
+    "verbose": false,
+    "execMap": {
+        "js": "node --harmony"
+    },
+    "watch": ["src/"],
+    "env": {
+        "NODE_ENV": "development"
+    },
+    "ext": "js,json"
+}

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/zadam/trilium.git"
   },
   "scripts": {
-    "start-server": "cross-env TRILIUM_DATA_DIR=./data TRILIUM_ENV=dev TRILIUM_SYNC_SERVER_HOST=http://tsyncserver:4000 node ./src/www",
-    "start-server-no-dir": "cross-env TRILIUM_ENV=dev TRILIUM_SYNC_SERVER_HOST=http://tsyncserver:4000 node ./src/www",
+    "start-server": "cross-env TRILIUM_DATA_DIR=./data TRILIUM_ENV=dev TRILIUM_SYNC_SERVER_HOST=http://tsyncserver:4000 nodemon ./src/www",
+    "start-server-no-dir": "cross-env TRILIUM_ENV=dev TRILIUM_SYNC_SERVER_HOST=http://tsyncserver:4000 nodemon ./src/www",
     "start-electron": "cross-env TRILIUM_DATA_DIR=./data TRILIUM_SYNC_SERVER_HOST=http://tsyncserver:4000 TRILIUM_ENV=dev electron --inspect=5858 .",
     "start-electron-no-dir": "cross-env TRILIUM_ENV=dev TRILIUM_SYNC_SERVER_HOST=http://tsyncserver:4000 electron --inspect=5858 .",
     "switch-server": "rm -rf ./node_modules/better-sqlite3 && npm install",
@@ -104,6 +104,7 @@
     "jasmine": "4.6.0",
     "jsdoc": "4.0.2",
     "lorem-ipsum": "2.0.8",
+    "nodemon": "^2.0.22",
     "rcedit": "3.0.1",
     "webpack": "5.78.0",
     "webpack-cli": "5.0.1"

--- a/src/services/ws.js
+++ b/src/services/ws.js
@@ -9,6 +9,18 @@ const protectedSessionService = require('./protected_session');
 const becca = require("../becca/becca");
 const AbstractBeccaEntity = require("../becca/entities/abstract_becca_entity");
 
+const env = require('./env');
+if (env.isDev()) {
+    const chokidar = require('chokidar');
+    const debounce = require('debounce');
+    const debounceReloadFronted = debounce(reloadFrontend, 200);
+    chokidar
+        .watch('src/public')
+        .on('add', debounceReloadFronted)
+        .on('change', debounceReloadFronted)
+        .on('unlink', debounceReloadFronted);
+}
+
 let webSocketServer;
 let lastSyncedPush = null;
 

--- a/src/services/ws.js
+++ b/src/services/ws.js
@@ -13,12 +13,12 @@ const env = require('./env');
 if (env.isDev()) {
     const chokidar = require('chokidar');
     const debounce = require('debounce');
-    const debounceReloadFronted = debounce(reloadFrontend, 200);
+    const debouncedReloadFrontend = debounce(reloadFrontend, 200);
     chokidar
         .watch('src/public')
-        .on('add', debounceReloadFronted)
-        .on('change', debounceReloadFronted)
-        .on('unlink', debounceReloadFronted);
+        .on('add', debouncedReloadFrontend)
+        .on('change', debouncedReloadFrontend)
+        .on('unlink', debouncedReloadFrontend);
 }
 
 let webSocketServer;


### PR DESCRIPTION
It leverages internel websocket to support frontend auto reloading and uses nodemon to enable backend auto reloading, which ignores frontend files(src/public), generally only reloads when necessarily.
It works fine in server developing, but server reloading not available in electron.
