### PR TITLE
fix:  match custom path strictly

### DIFF
--- a/src/routes/custom.js
+++ b/src/routes/custom.js
@@ -19,7 +19,7 @@ function handleRequest(req, res) {
             continue;
         }
 
-        const regex = new RegExp(attr.value);
+        const regex = new RegExp(`^${attr.value}$`);
         let match;
 
         try {


### PR DESCRIPTION
It's a loose match now, e.g. "note" will match "text-note","file-note".