### PR TITLE
Return created/existing branch in `EnsureNoteIsPresentInParent`

### DIFF
--- a/src/services/backend_script_api.js
+++ b/src/services/backend_script_api.js
@@ -137,13 +137,13 @@ function BackendScriptApi(currentNote, apiParams) {
     this.getNoteWithLabel = attributeService.getNoteWithLabel;
 
     /**
-     * If there's no branch between note and parent note, create one. Otherwise, do nothing.
+     * If there's no branch between note and parent note, create one. Otherwise, do nothing. Returns the new or existing branch.
      *
      * @method
      * @param {string} noteId
      * @param {string} parentNoteId
      * @param {string} prefix - if branch will be created between note and parent note, set this prefix
-     * @returns {void}
+     * @returns {{branch: BBranch|null}}
      */
     this.ensureNoteIsPresentInParent = cloningService.ensureNoteIsPresentInParent;
 

--- a/src/services/cloning.js
+++ b/src/services/cloning.js
@@ -61,15 +61,15 @@ function cloneNoteToBranch(noteId, parentBranchId, prefix) {
 
 function ensureNoteIsPresentInParent(noteId, parentNoteId, prefix) {
     if (isNoteDeleted(noteId)) {
-        return { success: false, message: `Note '${noteId}' is deleted.` };
+        return { branch: null, success: false, message: `Note '${noteId}' is deleted.` };
     } else if (isNoteDeleted(parentNoteId)) {
-        return { success: false, message: `Note '${parentNoteId}' is deleted.` };
+        return { branch: null, success: false, message: `Note '${parentNoteId}' is deleted.` };
     }
 
     const parentNote = becca.getNote(parentNoteId);
 
     if (parentNote.type === 'search') {
-        return { success: false, message: "Can't clone into a search note" };
+        return { branch: null, success: false, message: "Can't clone into a search note" };
     }
 
     const validationResult = treeService.validateParentChild(parentNoteId, noteId);
@@ -87,7 +87,7 @@ function ensureNoteIsPresentInParent(noteId, parentNoteId, prefix) {
 
     log.info(`Ensured note '${noteId}' is in parent note '${parentNoteId}' with prefix '${branch.prefix}'`);
 
-    return { success: true };
+    return { branch: branch, success: true };
 }
 
 function ensureNoteIsAbsentFromParent(noteId, parentNoteId) {

--- a/src/services/tree.js
+++ b/src/services/tree.js
@@ -31,12 +31,12 @@ function getNotes(noteIds) {
 
 function validateParentChild(parentNoteId, childNoteId, branchId = null) {
     if (['root', '_hidden', '_share', '_lbRoot', '_lbAvailableLaunchers', '_lbVisibleLaunchers'].includes(childNoteId)) {
-        return { success: false, message: `Cannot change this note's location.`};
+        return { branch: null, success: false, message: `Cannot change this note's location.`};
     }
 
     if (parentNoteId === 'none') {
         // this shouldn't happen
-        return { success: false, message: `Cannot move anything into 'none' parent.` };
+        return { branch: null, success: false, message: `Cannot move anything into 'none' parent.` };
     }
 
     const existing = getExistingBranch(parentNoteId, childNoteId);
@@ -46,6 +46,7 @@ function validateParentChild(parentNoteId, childNoteId, branchId = null) {
         const childNote = becca.getNote(childNoteId);
 
         return {
+            branch: existing,
             success: false,
             message: `Note "${childNote.title}" note already exists in the "${parentNote.title}".`
         };
@@ -53,6 +54,7 @@ function validateParentChild(parentNoteId, childNoteId, branchId = null) {
 
     if (!checkTreeCycle(parentNoteId, childNoteId)) {
         return {
+            branch: null,
             success: false,
             message: 'Moving/cloning note here would create cycle.'
         };
@@ -60,12 +62,13 @@ function validateParentChild(parentNoteId, childNoteId, branchId = null) {
 
     if (parentNoteId !== '_lbBookmarks' && becca.getNote(parentNoteId).type === 'launcher') {
         return {
+            branch: null,
             success: false,
             message: 'Launcher note cannot have any children.'
         };
     }
 
-    return { success: true };
+    return { branch: null, success: true };
 }
 
 function getExistingBranch(parentNoteId, childNoteId) {


### PR DESCRIPTION
use case: wanted to activate an ensured branch (as well as set branch prefix even if it already existed), this makes that process less janky

if this isn't desirable, an alternative might just be an API exposing `treeService.getExistingBranch` which takes in parent note/child note rather than branch ID to get a branch (although this is still cleaner than having to do that afterwards)