### PR TITLE
Allow etapi to update attribute fields isInheritable, position

### DIFF
--- a/src/etapi/attributes.js
+++ b/src/etapi/attributes.js
@@ -17,7 +17,8 @@ function register(router) {
         'type': [v.mandatory, v.notNull, v.isAttributeType],
         'name': [v.mandatory, v.notNull, v.isString],
         'value': [v.notNull, v.isString],
-        'isInheritable': [v.notNull, v.isBoolean]
+        'isInheritable': [v.notNull, v.isBoolean],
+        'position': [v.notNull, v.isInteger]
     };
 
     eu.route(router, 'post' ,'/etapi/attributes', (req, res, next) => {
@@ -40,7 +41,9 @@ function register(router) {
     });
 
     const ALLOWED_PROPERTIES_FOR_PATCH = {
-        'value': [v.notNull, v.isString]
+        'value': [v.notNull, v.isString],
+        'isInheritable': [v.notNull, v.isBoolean],
+        'position': [v.notNull, v.isInteger]
     };
 
     eu.route(router, 'patch' ,'/etapi/attributes/:attributeId', (req, res, next) => {

--- a/src/etapi/attributes.js
+++ b/src/etapi/attributes.js
@@ -42,7 +42,6 @@ function register(router) {
 
     const ALLOWED_PROPERTIES_FOR_PATCH = {
         'value': [v.notNull, v.isString],
-        'isInheritable': [v.notNull, v.isBoolean],
         'position': [v.notNull, v.isInteger]
     };
 


### PR DESCRIPTION
This PR allows etapi clients to update attribute fields isInheritable and position. I'm developing a Python library for working with Trilium and this will enable idiomatic management of attributes: the user simply maintains a Python list of attributes, and positions are automatically calculated. 

Branches already support updating position, and isInheritable is allowed for attribute creation, so this seems to be a mere oversight.