### PR TITLE
Make active ribbon item more obvious

### DIFF
--- a/src/public/app/widgets/containers/ribbon_container.js
+++ b/src/public/app/widgets/containers/ribbon_container.js
@@ -39,7 +39,7 @@ const TPL = `
     
     .ribbon-tab-title.active {
         color: var(--main-text-color);
-        border-bottom: 1px solid var(--main-text-color);
+        border-bottom: 3px solid var(--main-text-color);
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
Currently:
![image](https://github.com/zadam/trilium/assets/10717998/9f55ab45-8640-4ed2-881f-900ab090a779)

Proposed Change:
![image](https://github.com/zadam/trilium/assets/10717998/a5dbb29f-429f-4332-b110-03237241f3bc)
