### PR TITLE
fix included note display

### DIFF
--- a/src/public/app/widgets/type_widgets/editable_text.js
+++ b/src/public/app/widgets/type_widgets/editable_text.js
@@ -51,7 +51,7 @@ const TPL = `
         cursor: text !important;
     }
     
-    .note-detail-editable-text *:not(figure):first-child {
+    .note-detail-editable-text *:not(figure,.include-note):first-child {
         margin-top: 0 !important;
     }
          


### PR DESCRIPTION
The display of a included note has been cut off if it's the first element. Maybe it would be better to exclude included notes from the margin rule.

from
![image](https://github.com/zadam/trilium/assets/32272399/2ec583e0-2450-4c55-ae88-f9c1ccbb422c)


to
![image](https://github.com/zadam/trilium/assets/32272399/419ae469-527a-4fd1-837c-54567c5007a7)
