### PR TITLE
Auto flex note title in tree

### DIFF
--- a/src/public/stylesheets/tree.css
+++ b/src/public/stylesheets/tree.css
@@ -11,6 +11,7 @@ span.fancytree-node.fancytree-hide {
 }
 
 .fancytree-title {
+    flex: auto;
     margin-left: 7px;
     outline: none;
     position: relative;


### PR DESCRIPTION
Quite often I seem to accidentally create child notes by accidentally clicking on the `+` button since it is so close to the note title. 

This change makes it a little harder to accidentally create child notes when clicking on the note title and has the added benefit of aligning all the `+` buttons.


Current:
![image](https://github.com/zadam/trilium/assets/10717998/a0802055-0b4c-435b-a483-c7855e31dfa9)

Proposed:
![image](https://github.com/zadam/trilium/assets/10717998/d8b9f92c-1987-490a-9fdb-e0bc9957cb56)
