### PR TITLE
Add an undefined check for cpuInfos

### DIFF
--- a/src/www
+++ b/src/www
@@ -93,7 +93,9 @@ async function startTrilium() {
     log.info(JSON.stringify(appInfo, null, 2));
 
     const cpuInfos = require('os').cpus();
-    log.info(`CPU model: ${cpuInfos[0].model}, logical cores: ${cpuInfos.length} freq: ${cpuInfos[0].speed} Mhz`); // for perf. issues it's good to know the rough configuration
+    if (cpuInfos && cpuInfos[0] !== undefined) {
+        log.info(`CPU model: ${cpuInfos[0].model}, logical cores: ${cpuInfos.length} freq: ${cpuInfos[0].speed} Mhz`); // for perf. issues it's good to know the rough configuration
+    }
 
     /**
      * Listen on provided port, on all network interfaces.


### PR DESCRIPTION
cpuInfos[0] is undefined on certain platforms like Termux on Android. 

```
TypeError: Cannot read properties of undefined (reading 'model')
    at startTrilium (/data/data/com.termux/files/home/tril/trilium/src/www:96:40)
    at Object.<anonymous> (/data/data/com.termux/files/home/tril/trilium/src/www:148:1)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47
TypeError: Cannot read properties of undefined (reading 'model')
    at startTrilium (/data/data/com.termux/files/home/tril/trilium/src/www:96:40)
    at Object.<anonymous> (/data/data/com.termux/files/home/tril/trilium/src/www:148:1)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47
```

Since this is just for logging, it seems like it's fine to disable it when missing.

Tested on Termux with the web client.



Should there be a log message for when cpuInfos is undefined?