### PR TITLE
Add buttons to reorder split panes

### DIFF
--- a/src/public/app/components/tab_manager.js
+++ b/src/public/app/components/tab_manager.js
@@ -451,15 +451,14 @@ export default class TabManager extends Component {
         this.tabsUpdate.scheduleUpdate();
     }
 
-    noteContextReorderEvent({ntxIdsInOrder}) {
-        const order = {};
-        let i = 0;
-
-        for (const ntxId of ntxIdsInOrder) {
-            order[ntxId] = i++;
-        }
+    noteContextReorderEvent({ntxIdsInOrder, mainNtxIdsInOrder}) {
+        const order = Object.fromEntries(ntxIdsInOrder.map((v, i) => [v, i]));
 
         this.children.sort((a, b) => order[a.ntxId] < order[b.ntxId] ? -1 : 1);
+
+        if (!!mainNtxIdsInOrder && mainNtxIdsInOrder.length === this.children.length) {
+            this.children.forEach((c, i) => c.mainNtxId = mainNtxIdsInOrder[i]);
+        }
 
         this.tabsUpdate.scheduleUpdate();
     }

--- a/src/public/app/components/tab_manager.js
+++ b/src/public/app/components/tab_manager.js
@@ -451,13 +451,21 @@ export default class TabManager extends Component {
         this.tabsUpdate.scheduleUpdate();
     }
 
-    noteContextReorderEvent({ntxIdsInOrder, mainNtxIdsInOrder}) {
+    noteContextReorderEvent({ntxIdsInOrder, oldMainNtxId, newMainNtxId}) {
         const order = Object.fromEntries(ntxIdsInOrder.map((v, i) => [v, i]));
 
         this.children.sort((a, b) => order[a.ntxId] < order[b.ntxId] ? -1 : 1);
 
-        if (!!mainNtxIdsInOrder && mainNtxIdsInOrder.length === this.children.length) {
-            this.children.forEach((c, i) => c.mainNtxId = mainNtxIdsInOrder[i]);
+        if (oldMainNtxId && newMainNtxId) {
+            this.children.forEach(c => {
+                if (c.ntxId === newMainNtxId) {
+                    // new main context has null mainNtxId
+                    c.mainNtxId = null;
+                } else if (c.ntxId === oldMainNtxId || c.mainNtxId === oldMainNtxId) {
+                    // old main context or subcontexts all have the new mainNtxId
+                    c.mainNtxId = newMainNtxId;
+                }
+            });
         }
 
         this.tabsUpdate.scheduleUpdate();

--- a/src/public/app/layouts/desktop_layout.js
+++ b/src/public/app/layouts/desktop_layout.js
@@ -75,6 +75,7 @@ import CodeButtonsWidget from "../widgets/floating_buttons/code_buttons.js";
 import ApiLogWidget from "../widgets/api_log.js";
 import HideFloatingButtonsButton from "../widgets/floating_buttons/hide_floating_buttons_button.js";
 import ScriptExecutorWidget from "../widgets/ribbon_widgets/script_executor.js";
+import MovePaneButton from "../widgets/buttons/move_pane_button.js";
 
 export default class DesktopLayout {
     constructor(customWidgets) {
@@ -123,6 +124,8 @@ export default class DesktopLayout {
                                         .child(new NoteIconWidget())
                                         .child(new NoteTitleWidget())
                                         .child(new SpacerWidget(0, 1))
+                                        .child(new MovePaneButton(true))
+                                        .child(new MovePaneButton(false))
                                         .child(new ClosePaneButton())
                                         .child(new CreatePaneButton())
                                     )

--- a/src/public/app/widgets/buttons/close_pane_button.js
+++ b/src/public/app/widgets/buttons/close_pane_button.js
@@ -7,6 +7,10 @@ export default class ClosePaneButton extends OnClickButtonWidget {
             && this.noteContext && !!this.noteContext.mainNtxId;
     }
 
+    async noteContextReorderEvent({ntxIdsInOrder}) {
+        this.refresh();
+    }
+
     constructor() {
         super();
 

--- a/src/public/app/widgets/buttons/move_pane_button.js
+++ b/src/public/app/widgets/buttons/move_pane_button.js
@@ -2,42 +2,6 @@ import OnClickButtonWidget from "./onclick_button.js";
 import appContext from "../../components/app_context.js";
 
 export default class MovePaneButton extends OnClickButtonWidget {
-    isEnabled() {
-        if (!super.isEnabled())
-            return false;
-        
-        if (this.isMovingLeft) {
-            // movable if the current context is not a main context, i.e. non-null mainNtxId
-            return !!this.noteContext?.mainNtxId;
-        } else {
-            const currentIndex = appContext.tabManager.noteContexts.findIndex(c => c.ntxId === this.ntxId);
-            const nextContext = appContext.tabManager.noteContexts[currentIndex + 1];
-            // movable if the next context is not null and not a main context, i.e. non-null mainNtxId
-            return !!nextContext?.mainNtxId;
-        }
-    }
-
-    initialRenderCompleteEvent() {
-        this.refresh();
-        super.initialRenderCompleteEvent();
-    }
-
-    async noteContextRemovedEvent({ntxIds}) {
-        this.refresh();
-    }
-
-    async newNoteContextCreatedEvent({noteContext}) {
-        this.refresh();
-    }
-
-    async noteContextSwitchEvent() {
-        this.refresh();
-    }
-
-    async noteContextReorderEvent({ntxIdsInOrder}) {
-        this.refresh();
-    }
-
     constructor(isMovingLeft) {
         super();
 
@@ -51,5 +15,33 @@ export default class MovePaneButton extends OnClickButtonWidget {
                 widget.triggerCommand("moveThisNoteSplit", {ntxId: widget.getClosestNtxId(), isMovingLeft: this.isMovingLeft});
             })
             .class("icon-action");
+    }
+
+    isEnabled() {
+        if (!super.isEnabled()) {
+            return false;
+        }
+
+        if (this.isMovingLeft) {
+            // movable if the current context is not a main context, i.e. non-null mainNtxId
+            return !!this.noteContext?.mainNtxId;
+        } else {
+            const currentIndex = appContext.tabManager.noteContexts.findIndex(c => c.ntxId === this.ntxId);
+            const nextContext = appContext.tabManager.noteContexts[currentIndex + 1];
+            // movable if the next context is not null and not a main context, i.e. non-null mainNtxId
+            return !!nextContext?.mainNtxId;
+        }
+    }
+
+    async noteContextRemovedEvent() {
+        this.refresh();
+    }
+
+    async newNoteContextCreatedEvent() {
+        this.refresh();
+    }
+
+    async noteContextReorderEvent() {
+        this.refresh();
     }
 }

--- a/src/public/app/widgets/buttons/move_pane_button.js
+++ b/src/public/app/widgets/buttons/move_pane_button.js
@@ -1,0 +1,55 @@
+import OnClickButtonWidget from "./onclick_button.js";
+import appContext from "../../components/app_context.js";
+
+export default class MovePaneButton extends OnClickButtonWidget {
+    isEnabled() {
+        if (!super.isEnabled())
+            return false;
+        
+        if (this.isMovingLeft) {
+            // movable if the current context is not a main context, i.e. non-null mainNtxId
+            return !!this.noteContext?.mainNtxId;
+        } else {
+            const currentIndex = appContext.tabManager.noteContexts.findIndex(c => c.ntxId === this.ntxId);
+            const nextContext = appContext.tabManager.noteContexts[currentIndex + 1];
+            // movable if the next context is not null and not a main context, i.e. non-null mainNtxId
+            return !!nextContext?.mainNtxId;
+        }
+    }
+
+    initialRenderCompleteEvent() {
+        this.refresh();
+        super.initialRenderCompleteEvent();
+    }
+
+    async noteContextRemovedEvent({ntxIds}) {
+        this.refresh();
+    }
+
+    async newNoteContextCreatedEvent({noteContext}) {
+        this.refresh();
+    }
+
+    async noteContextSwitchEvent() {
+        this.refresh();
+    }
+
+    async noteContextReorderEvent({ntxIdsInOrder}) {
+        this.refresh();
+    }
+
+    constructor(isMovingLeft) {
+        super();
+
+        this.isMovingLeft = isMovingLeft;
+
+        this.icon(isMovingLeft ? "bx-chevron-left" : "bx-chevron-right")
+            .title(isMovingLeft ? "Move left" : "Move right")
+            .titlePlacement("bottom")
+            .onClick(async (widget, e) => {
+                e.stopPropagation();
+                widget.triggerCommand("moveThisNoteSplit", {ntxId: widget.getClosestNtxId(), isMovingLeft: this.isMovingLeft});
+            })
+            .class("icon-action");
+    }
+}

--- a/src/public/app/widgets/containers/split_note_container.js
+++ b/src/public/app/widgets/containers/split_note_container.js
@@ -1,6 +1,5 @@
 import FlexContainer from "./flex_container.js";
 import appContext from "../../components/app_context.js";
-import NoteContext from "../../components/note_context.js";
 
 export default class SplitNoteContainer extends FlexContainer {
     constructor(widgetFactory) {

--- a/src/public/app/widgets/containers/split_note_container.js
+++ b/src/public/app/widgets/containers/split_note_container.js
@@ -86,28 +86,31 @@ export default class SplitNoteContainer extends FlexContainer {
         const leftIndex = isMovingLeft ? currentIndex - 1 : currentIndex;
 
         if (currentIndex === -1 || leftIndex < 0 || leftIndex + 1 >= contexts.length) {
-            logError("invalid context!");
+            logError(`invalid context! currentIndex: ${currentIndex}, leftIndex: ${leftIndex}, contexts.length: ${contexts.length}`);
             return;
         }
 
-        if (contexts[leftIndex].isEmpty() && contexts[leftIndex + 1].isEmpty())
+        if (contexts[leftIndex].isEmpty() && contexts[leftIndex + 1].isEmpty()) {
             // no op
             return;
+        }
 
         const ntxIds = contexts.map(c => c.ntxId);
-        const mainNtxIds = contexts.map(c => c.mainNtxId);
+        const newNtxIds = [
+            ...ntxIds.slice(0, leftIndex),
+            ntxIds[leftIndex + 1],
+            ntxIds[leftIndex],
+            ...ntxIds.slice(leftIndex + 2),
+        ];
+        const isChangingMainContext = !contexts[leftIndex].mainNtxId;
 
         this.triggerCommand("noteContextReorder", {
-            ntxIdsInOrder: [
-                ...ntxIds.slice(0, leftIndex),
-                ntxIds[leftIndex + 1],
-                ntxIds[leftIndex],
-                ...ntxIds.slice(leftIndex + 2),
-            ],
-            oldNtxIdsInOrder: ntxIds,
-            mainNtxIdsInOrder: mainNtxIds.map(id => id === ntxIds[leftIndex] ? ntxIds[leftIndex + 1] : id)
+            ntxIdsInOrder: newNtxIds,
+            oldMainNtxId: isChangingMainContext ? ntxIds[leftIndex] : null,
+            newMainNtxId: isChangingMainContext ? ntxIds[leftIndex + 1]: null,
         });
 
+        // reorder the note context widgets
         this.$widget.find(`[data-ntx-id="${ntxIds[leftIndex]}"]`)
             .insertAfter(this.$widget.find(`[data-ntx-id="${ntxIds[leftIndex + 1]}"]`));
 

--- a/src/public/app/widgets/tab_row.js
+++ b/src/public/app/widgets/tab_row.js
@@ -609,20 +609,15 @@ export default class TabRowWidget extends BasicWidget {
         this.updateTabById(noteContext.mainNtxId || noteContext.ntxId);
     }
 
-    noteContextReorderEvent({ntxIdsInOrder, oldNtxIdsInOrder, mainNtxIdsInOrder}) {
-        if (!oldNtxIdsInOrder || !mainNtxIdsInOrder
-            || ntxIdsInOrder.length !== oldNtxIdsInOrder.length
-            || ntxIdsInOrder.length !== mainNtxIdsInOrder.length
-        )
+    noteContextReorderEvent({oldMainNtxId, newMainNtxId}) {
+        if (!oldMainNtxId || !newMainNtxId) {
+            // no need to update tab row
             return;
+        }
 
-        ntxIdsInOrder.forEach((id, i) => {
-            // update main context that is not a tab
-            if (!mainNtxIdsInOrder[i] && this.getTabById(id).length === 0) {
-                this.getTabById(oldNtxIdsInOrder[i]).attr("data-ntx-id", id);
-                this.updateTabById(id);
-            }
-        });
+        // update tab id for the new main context
+        this.getTabById(oldMainNtxId).attr("data-ntx-id", newMainNtxId);
+        this.updateTabById(newMainNtxId);        
     }
 
     updateTabById(ntxId) {

--- a/src/public/app/widgets/tab_row.js
+++ b/src/public/app/widgets/tab_row.js
@@ -609,6 +609,22 @@ export default class TabRowWidget extends BasicWidget {
         this.updateTabById(noteContext.mainNtxId || noteContext.ntxId);
     }
 
+    noteContextReorderEvent({ntxIdsInOrder, oldNtxIdsInOrder, mainNtxIdsInOrder}) {
+        if (!oldNtxIdsInOrder || !mainNtxIdsInOrder
+            || ntxIdsInOrder.length !== oldNtxIdsInOrder.length
+            || ntxIdsInOrder.length !== mainNtxIdsInOrder.length
+        )
+            return;
+
+        ntxIdsInOrder.forEach((id, i) => {
+            // update main context that is not a tab
+            if (!mainNtxIdsInOrder[i] && this.getTabById(id).length === 0) {
+                this.getTabById(oldNtxIdsInOrder[i]).attr("data-ntx-id", id);
+                this.updateTabById(id);
+            }
+        });
+    }
+
     updateTabById(ntxId) {
         const $tab = this.getTabById(ntxId);
 


### PR DESCRIPTION
### Background
I use the split-pane function quite often to view other reference/literature notes when doing my writing. Sometimes I need to compare difference versions of my work, and I find it quite clumsy to swap the notes in the two panes, i.e. focus into the left pane, jump to another note, focus into the right pane, and then jump to another note.  

It would be nice if we can somehow reorder the panes to better organize the notes. The reordering/swapping buttons would also allow "closing the left pane" without using the Jump to Note function, that would become a simple swap followed by closing the right pane.

### Proposed funtion
Introduce "Move left" and "Move right" buttons next to "Create new split" and "Close this pane" buttons for users to reorder split panes. When split panes are used, these buttons will appear given that the moving direction is valid in relation to other panes on the screen. 

![2023-05-30_03-18-15](https://github.com/zadam/trilium/assets/10493889/69d183b7-ceb4-46bd-a801-f75eff640fb8)

![2023-05-30_03-18-27](https://github.com/zadam/trilium/assets/10493889/c6f56579-79ce-45d7-a2f8-cfabf04784fd)

In case there are more than two panes, both buttons will be shown in the middle panes. Also, when one of the panes involved in the move operation is empty, it has the same effect as copying the non-empty pane to the empty one.  

![2023-05-30_03-22-02](https://github.com/zadam/trilium/assets/10493889/634e476d-95d3-4275-98b3-067809afb602)

![2023-05-30_03-22-06](https://github.com/zadam/trilium/assets/10493889/db9846e5-da6d-42a1-9e79-34d16c001c34)

In this implementation, the note contexts will switch directly to their new note paths. A small catch is that the scrolling position in the panes will not be preserved. I think it might be possible to utilize the `noteContextReorder` event, but I found it quite complicated since we also need to update the main context ID of all the subcontexts before refreshing the UI. Anyway, I think the current proof of concept should be good enough for most use cases.