### PR TITLE
Reopen recently closed tab/split in place

### DIFF
--- a/src/public/app/widgets/buttons/move_pane_button.js
+++ b/src/public/app/widgets/buttons/move_pane_button.js
@@ -44,4 +44,8 @@ export default class MovePaneButton extends OnClickButtonWidget {
     async noteContextReorderEvent() {
         this.refresh();
     }
+
+    async contextsReopenedEvent() {
+        this.refresh();
+    }
 }

--- a/src/public/app/widgets/containers/split_note_container.js
+++ b/src/public/app/widgets/containers/split_note_container.js
@@ -136,6 +136,15 @@ export default class SplitNoteContainer extends FlexContainer {
         }
     }
 
+    contextsReopenedEvent({ntxId, afterNtxId}) {
+        if (ntxId === undefined || afterNtxId === undefined) {
+            // no single split reopened
+            return;
+        }
+        this.$widget.find(`[data-ntx-id="${ntxId}"]`)
+            .insertAfter(this.$widget.find(`[data-ntx-id="${afterNtxId}"]`));
+    }
+
     async refresh() {
         this.toggleExt(true);
     }

--- a/src/public/app/widgets/tab_row.js
+++ b/src/public/app/widgets/tab_row.js
@@ -620,6 +620,15 @@ export default class TabRowWidget extends BasicWidget {
         this.updateTabById(newMainNtxId);        
     }
 
+    contextsReopenedEvent({mainNtxId, tabPosition}) {
+        if (mainNtxId === undefined || tabPosition === undefined) {
+            // no tab reopened
+            return;
+        }
+        const tabEl = this.getTabById(mainNtxId)[0];
+        tabEl.parentNode.insertBefore(tabEl, this.tabEls[tabPosition]);
+    }
+
     updateTabById(ntxId) {
         const $tab = this.getTabById(ntxId);
 


### PR DESCRIPTION
As suggested by @adityaverma415 in #3993, when closing a tab (one or more splits) or a single split, the position will be stored in `tabManager.recentlyClosedTabs` so that when the tab/split is reopened, they can be reordered back to their original position.

![2023-06-03_05-58-49](https://github.com/zadam/trilium/assets/10493889/1da097e3-829d-4aa2-b41d-d9bd44a308de)
