### PR TITLE
Fix shortcuts not resetting to default

### DIFF
--- a/src/public/app/widgets/type_widgets/options/shortcuts.js
+++ b/src/public/app/widgets/type_widgets/options/shortcuts.js
@@ -116,11 +116,11 @@ export default class KeyboardShortcutsOptions extends OptionsWidget {
                 return;
             }
 
-            $table.find('input.form-control').each(function() {
-                const defaultShortcuts = this.$widget.find(this).attr('data-default-keyboard-shortcuts');
+            $table.find('input.form-control').each((_index, el) => {
+                const defaultShortcuts = this.$widget.find(el).attr('data-default-keyboard-shortcuts');
 
-                if (this.$widget.find(this).val() !== defaultShortcuts) {
-                    this.$widget.find(this)
+                if (this.$widget.find(el).val() !== defaultShortcuts) {
+                    this.$widget.find(el)
                         .val(defaultShortcuts)
                         .trigger('change');
                 }


### PR DESCRIPTION
### Trilium Version
v0.60.1-beta, as of commit d3bf325

### What operating system are you using?
Other (specify below)

### What is your setup?
Local (no sync)

### Operating System Version
Windows 10 version 22H2 with WSL2 Ubuntu 20.04

### Description
In the Options/Shortcutes page, the `Set all shortcuts to the default` button is not working.

Current:
![2023-06-03_22-12-34](https://github.com/zadam/trilium/assets/10493889/a5da197a-ee76-419c-90e9-3c6a24df8f1e)

Fixed:
![2023-06-03_22-11-34](https://github.com/zadam/trilium/assets/10493889/80b7c9ab-4434-4e78-a353-207263033b62)
