### PR TITLE
Fix SQL Console error messages

### DIFF
--- a/src/public/app/components/entrypoints.js
+++ b/src/public/app/components/entrypoints.js
@@ -173,7 +173,7 @@ export default class Entrypoints extends Component {
             const resp = await server.post(`sql/execute/${note.noteId}`);
 
             if (!resp.success) {
-                toastService.showError(`Error occurred while executing SQL query: ${resp.message}`);
+                toastService.showError(`Error occurred while executing SQL query: ${resp.error}`);
             }
 
             await appContext.triggerEvent('sqlQueryResults', {ntxId: ntxId, results: resp.results});


### PR DESCRIPTION
Fixes #4015 

Server replies with an `error` key but the frontend is expecting a `message` key, this unifies both sides to use `error`. Details in #4015