### PR TITLE
Ignore SQL comments in query console

### DIFF
--- a/src/routes/api/sql.js
+++ b/src/routes/api/sql.js
@@ -36,6 +36,11 @@ function execute(req) {
             if (!query) {
                 continue;
             }
+            
+            while (query.startsWith('-- ') {
+                // Query starts with one or more SQL comments, discard these before we execute.
+                query = query.substr(query.indexOf('\n') + 1)
+            }
 
             if (query.toLowerCase().startsWith('select') || query.toLowerCase().startsWith('with')) {
                 results.push(sql.getRows(query));

--- a/src/routes/api/sql.js
+++ b/src/routes/api/sql.js
@@ -33,13 +33,14 @@ function execute(req) {
         for (let query of queries) {
             query = query.trim();
 
-            if (!query) {
-                continue;
-            }
-            
             while (query.startsWith('-- ') {
                 // Query starts with one or more SQL comments, discard these before we execute.
-                query = query.substr(query.indexOf('\n') + 1)
+                const pivot = query.indexOf('\n');
+                query = pivot > 0 ? query.substr(pivot + 1).trim() : "";
+            }
+            
+            if (!query) {
+                continue;
             }
 
             if (query.toLowerCase().startsWith('select') || query.toLowerCase().startsWith('with')) {


### PR DESCRIPTION
Currently the SQL console doesn't return rows if a query starts with a comment. Consider the following:

```sql
SELECT * FROM notes WHERE title = 'root';
---
-- SELECT * FROM branches WHERE parentNoteId = 'root';
SELECT * FROM branches WHERE parentNoteId = '_hidden';
```

The SQL console results are:
```
{
	"changes": 0,
	"lastInsertRowid": 16363
}
```

This PR allows results from both queries to be returned. Note that it does look like a multi-statement SQL query that includes both `SELECT` and non-`SELECT` (eg, `UPDATE`) queries discards the result of the `SELECT` in the frontend. This is probably not a problem in real-world usages but might be worth fixing.