### PR TITLE
Feature/add clippings existing url

### DIFF
--- a/src/routes/api/clipper.js
+++ b/src/routes/api/clipper.js
@@ -16,17 +16,20 @@ const htmlSanitizer = require('../../services/html_sanitizer');
 const {formatAttrForSearch} = require("../../services/attribute_formatter");
 
 function findClippingNote(clipperInboxNote, pageUrl) {
-    const notes = clipperInboxNote.searchNotesInSubtree(
-        formatAttrForSearch({
-            type: 'label',
-            name: "pageUrl",
-            value: pageUrl
-        }, true)
-    );
+    //Avoid searching for empty of browser pages like about:blank
+    if (pageUrl.trim().length > 1 && pageUrl.trim().indexOf('about:') != 0 ){
+        const notes = clipperInboxNote.searchNotesInSubtree(
+            formatAttrForSearch({
+                type: 'label',
+                name: "pageUrl",
+                value: pageUrl
+            }, true)
+        );
 
-    for (const note of notes) {
-        if (note.getOwnedLabelValue('clipType') === 'note') {
-            return note;
+        for (const note of notes) {
+            if (note.getOwnedLabelValue('clipType') === 'note') {
+                return note;
+            }
         }
     }
 

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -286,6 +286,7 @@ function register(app) {
     route(POST, '/api/clipper/clippings', clipperMiddleware, clipperRoute.addClipping, apiResultHandler);
     route(POST, '/api/clipper/notes', clipperMiddleware, clipperRoute.createNote, apiResultHandler);
     route(POST, '/api/clipper/open/:noteId', clipperMiddleware, clipperRoute.openNote, apiResultHandler);
+    route(GET, '/api/clipper/notes-by-url/:noteUrl', clipperMiddleware, clipperRoute.findNotesByUrl, apiResultHandler);
 
     apiRoute(GET, '/api/similar-notes/:noteId', similarNotesRoute.getSimilarNotes);
 


### PR DESCRIPTION
#4074 
I only touched `clipper.js`, this should keep the main functionality intact.
I had to fix both `addClipping` and `createNote` functions, since they are responsible for creating notes with type `clipping` (used in trilium-web-clipper with the select+right click menu) and the `note` (used in trilium-web-clipper main menu).
I also fixed the `processContent` function because it would sometimes add content with not closed tags, so i opted to use jsdom to parse the content before adding it to the note.
Lastly, in order for the `<br>` tag to work correctly when appending notes with content that is just a string, i opted to add such content inside a `<p>` tag. This check is done with a regex which should be sufficient although not perfect

### Additional Notes
This PR includes exposing a new clipper endpoint 
`/api/clipper/notes-by-url/:noteUrl` that is needed by zadam/trilium-web-clipper#54