### PR TITLE
Implement saving of global search string.

### DIFF
--- a/src/public/app/widgets/search_options/search_string.js
+++ b/src/public/app/widgets/search_options/search_string.js
@@ -2,6 +2,7 @@ import AbstractSearchOption from "./abstract_search_option.js";
 import SpacedUpdate from "../../services/spaced_update.js";
 import server from "../../services/server.js";
 import shortcutService from "../../services/shortcuts.js";
+import appContext from "../../components/app_context.js";
 
 const TPL = `
 <tr>
@@ -56,6 +57,7 @@ export default class SearchString extends AbstractSearchOption {
 
         this.spacedUpdate = new SpacedUpdate(async () => {
             const searchString = this.$searchString.val();
+            appContext.lastSearchString = searchString;
 
             await this.setAttribute('label', 'searchString', searchString);
 
@@ -84,6 +86,7 @@ export default class SearchString extends AbstractSearchOption {
     }
 
     focusOnSearchDefinitionEvent() {
-        this.$searchString.focus();
+        this.$searchString.val(appContext.lastSearchString).focus().select();
+        this.spacedUpdate.scheduleUpdate();
     }
 }


### PR DESCRIPTION
This implements point 1 of [issue 868](https://github.com/zadam/trilium/issues/868).

After performing a search, when returning to the global search tab the previous search term is now retained and preselected, making it easier to repeat the same search or modify it.