### PR TITLE
Disable Search in note button in global search context.

### DIFF
--- a/src/public/app/widgets/buttons/note_actions.js
+++ b/src/public/app/widgets/buttons/note_actions.js
@@ -81,7 +81,7 @@ export default class NoteActionsWidget extends NoteContextAwareWidget {
     }
 
     refreshWithNote(note) {
-        this.toggleDisabled(this.$findInTextButton, ['text', 'code', 'book', 'search'].includes(note.type));
+        this.toggleDisabled(this.$findInTextButton, ['text', 'code', 'book'].includes(note.type));
 
         this.toggleDisabled(this.$showSourceButton, ['text', 'relationMap', 'mermaid'].includes(note.type));
 


### PR DESCRIPTION
This button doesn't actually do anything in the global search window, so it should be greyed out/disabled.