### PR TITLE
fix: launcher-button style

### DIFF
--- a/src/public/stylesheets/style.css
+++ b/src/public/stylesheets/style.css
@@ -925,6 +925,7 @@ body {
     color: var(--launcher-pane-text-color);
     background-color: var(--launcher-pane-background-color);
     height: 53px;
+    width: 100%;
 }
 
 #launcher-pane .icon-action:hover {


### PR DESCRIPTION
![image](https://github.com/zadam/trilium/assets/32272399/fe486cae-953b-4da8-952d-5b1dc9a30468)
The calendar icon is not in the middle because its width is less than other icons.