### PR TITLE
Use a list instead of dropdown for jump-to-note

### DIFF
--- a/src/public/app/services/note_autocomplete.js
+++ b/src/public/app/services/note_autocomplete.js
@@ -140,8 +140,9 @@ function initNoteAutocomplete($el, options) {
     let autocompleteOptions = {};
     if (options.container) {
         autocompleteOptions.dropdownMenuContainer = options.container;
+        autocompleteOptions.debug = true;   // don't close on blur
     } else {
-        autocompleteOptions.appendTo = document.querySelector('body');
+        autocompleteOptions.appendTo = document.querySelector('body');        
     }
 
     $el.autocomplete({

--- a/src/public/app/services/note_autocomplete.js
+++ b/src/public/app/services/note_autocomplete.js
@@ -106,7 +106,7 @@ function initNoteAutocomplete($el, options) {
     $el.addClass("note-autocomplete-input");
 
     const $clearTextButton = $("<a>")
-            .addClass("input-group-text input-clearer-button bx bx-x")
+            .addClass("input-group-text input-clearer-button bx bxs-tag-x")
             .prop("title", "Clear text field");
 
     const $showRecentNotesButton = $("<a>")

--- a/src/public/app/services/note_autocomplete.js
+++ b/src/public/app/services/note_autocomplete.js
@@ -137,8 +137,15 @@ function initNoteAutocomplete($el, options) {
         return false;
     });
 
+    let autocompleteOptions = {};
+    if (options.container) {
+        autocompleteOptions.dropdownMenuContainer = options.container;
+    } else {
+        autocompleteOptions.appendTo = document.querySelector('body');
+    }
+
     $el.autocomplete({
-        appendTo: document.querySelector('body'),
+        ...autocompleteOptions,
         hint: false,
         autoselect: true,
         // openOnFocus has to be false, otherwise re-focus (after return from note type chooser dialog) forces

--- a/src/public/app/services/note_autocomplete.js
+++ b/src/public/app/services/note_autocomplete.js
@@ -141,12 +141,11 @@ function initNoteAutocomplete($el, options) {
     if (options.container) {
         autocompleteOptions.dropdownMenuContainer = options.container;
         autocompleteOptions.debug = true;   // don't close on blur
-    } else {
-        autocompleteOptions.appendTo = document.querySelector('body');        
     }
 
     $el.autocomplete({
         ...autocompleteOptions,
+        appendTo: document.querySelector('body'),
         hint: false,
         autoselect: true,
         // openOnFocus has to be false, otherwise re-focus (after return from note type chooser dialog) forces

--- a/src/public/app/widgets/dialogs/jump_to_note.js
+++ b/src/public/app/widgets/dialogs/jump_to_note.js
@@ -8,10 +8,8 @@ const TPL = `<div class="jump-to-note-dialog modal mx-auto" tabindex="-1" role="
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <div class="form-group" style="flex-grow: 1;">
-                    <div class="input-group">
-                        <input class="jump-to-note-autocomplete form-control" placeholder="search for note by its name">
-                    </div>
+                <div class="input-group">
+                    <input class="jump-to-note-autocomplete form-control" placeholder="search for note by its name">
                 </div>
 
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">

--- a/src/public/app/widgets/dialogs/jump_to_note.js
+++ b/src/public/app/widgets/dialogs/jump_to_note.js
@@ -20,6 +20,8 @@ const TPL = `<div class="jump-to-note-dialog modal mx-auto" tabindex="-1" role="
                         <input class="jump-to-note-autocomplete form-control" placeholder="search for note by its name">
                     </div>
                 </div>
+
+                <div class="jump-to-note-results"></div>
             </div>
             <div class="modal-footer">
                 <button class="show-in-full-text-button btn btn-sm">Search in full text <kbd>Ctrl+Enter</kbd></button>
@@ -40,6 +42,7 @@ export default class JumpToNoteDialog extends BasicWidget {
     doRender() {
         this.$widget = $(TPL);
         this.$autoComplete = this.$widget.find(".jump-to-note-autocomplete");
+        this.$results = this.$widget.find(".jump-to-note-results");
         this.$showInFullTextButton = this.$widget.find(".show-in-full-text-button");
         this.$showInFullTextButton.on('click', e => this.showInFullText(e));
 
@@ -56,7 +59,10 @@ export default class JumpToNoteDialog extends BasicWidget {
     }
 
     async refresh() {
-        noteAutocompleteService.initNoteAutocomplete(this.$autoComplete, {hideGoToSelectedNoteButton: true})
+        noteAutocompleteService.initNoteAutocomplete(this.$autoComplete, {
+            hideGoToSelectedNoteButton: true,
+            container: this.$results
+        })
             // clear any event listener added in previous invocation of this function
             .off('autocomplete:noteselected')
             .on('autocomplete:noteselected', function (event, suggestion, dataset) {

--- a/src/public/app/widgets/dialogs/jump_to_note.js
+++ b/src/public/app/widgets/dialogs/jump_to_note.js
@@ -21,7 +21,7 @@ const TPL = `<div class="jump-to-note-dialog modal mx-auto" tabindex="-1" role="
                     </div>
                 </div>
 
-                <div class="jump-to-note-results"></div>
+                <div class="algolia-autocomplete-container jump-to-note-results"></div>
             </div>
             <div class="modal-footer">
                 <button class="show-in-full-text-button btn btn-sm">Search in full text <kbd>Ctrl+Enter</kbd></button>

--- a/src/public/app/widgets/dialogs/jump_to_note.js
+++ b/src/public/app/widgets/dialogs/jump_to_note.js
@@ -8,19 +8,17 @@ const TPL = `<div class="jump-to-note-dialog modal mx-auto" tabindex="-1" role="
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">Jump to note</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div class="form-group">
-                    <label for="jump-to-note-autocomplete">Note</label>
+                <div class="form-group" style="flex-grow: 1;">
                     <div class="input-group">
                         <input class="jump-to-note-autocomplete form-control" placeholder="search for note by its name">
                     </div>
                 </div>
 
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
                 <div class="algolia-autocomplete-container jump-to-note-results"></div>
             </div>
             <div class="modal-footer">

--- a/src/public/app/widgets/dialogs/jump_to_note.js
+++ b/src/public/app/widgets/dialogs/jump_to_note.js
@@ -58,6 +58,7 @@ export default class JumpToNoteDialog extends BasicWidget {
 
     async refresh() {
         noteAutocompleteService.initNoteAutocomplete(this.$autoComplete, {
+            allowCreatingNotes: true,
             hideGoToSelectedNoteButton: true,
             container: this.$results
         })

--- a/src/public/stylesheets/style.css
+++ b/src/public/stylesheets/style.css
@@ -504,6 +504,12 @@ table.promoted-attributes-in-tooltip td, table.promoted-attributes-in-tooltip th
     z-index: 2000 !important;
 }
 
+.algolia-autocomplete-container .aa-dropdown-menu {
+    position: inherit !important;
+    max-height: 40vh;
+    overflow: scroll;
+}
+
 .algolia-autocomplete .aa-input, .algolia-autocomplete .aa-hint {
     width: 100%;
 }

--- a/src/public/stylesheets/style.css
+++ b/src/public/stylesheets/style.css
@@ -1081,7 +1081,7 @@ textarea {
 }
 
 .jump-to-note-dialog .modal-body {
-    padding: 0 1rem;
+    padding: 0;
 }
 
 .jump-to-note-results .aa-dropdown-menu {
@@ -1089,5 +1089,5 @@ textarea {
 }
 
 .jump-to-note-results .aa-suggestions {
-    padding: 1rem 0;
+    padding: 1rem;
 }

--- a/src/public/stylesheets/style.css
+++ b/src/public/stylesheets/style.css
@@ -526,18 +526,18 @@ table.promoted-attributes-in-tooltip td, table.promoted-attributes-in-tooltip th
     margin: 0;
 }
 
-.algolia-autocomplete .aa-dropdown-menu .aa-suggestion {
+.aa-dropdown-menu .aa-suggestion {
     cursor: pointer;
     padding: 5px;
     margin: 0;
 }
 
-.algolia-autocomplete .aa-dropdown-menu .aa-suggestion p {
+.aa-dropdown-menu .aa-suggestion p {
     padding: 0;
     margin: 0;
 }
 
-.algolia-autocomplete .aa-dropdown-menu .aa-suggestion.aa-cursor {
+.aa-dropdown-menu .aa-suggestion.aa-cursor {
     color: var(--active-item-text-color);
     background-color: var(--active-item-background-color);
 }

--- a/src/public/stylesheets/style.css
+++ b/src/public/stylesheets/style.css
@@ -506,7 +506,7 @@ table.promoted-attributes-in-tooltip td, table.promoted-attributes-in-tooltip th
 
 .algolia-autocomplete-container .aa-dropdown-menu {
     position: inherit !important;    
-    overflow: scroll;
+    overflow: auto;
 }
 
 .algolia-autocomplete .aa-input, .algolia-autocomplete .aa-hint {

--- a/src/public/stylesheets/style.css
+++ b/src/public/stylesheets/style.css
@@ -1075,6 +1075,11 @@ textarea {
     top: 8px;
 }
 
+.jump-to-note-dialog .modal-header {
+    align-items: center;
+    padding-bottom: 1rem !important;
+}
+
 .jump-to-note-dialog .modal-body {
     padding: 0 1rem;
 }

--- a/src/public/stylesheets/style.css
+++ b/src/public/stylesheets/style.css
@@ -505,8 +505,7 @@ table.promoted-attributes-in-tooltip td, table.promoted-attributes-in-tooltip th
 }
 
 .algolia-autocomplete-container .aa-dropdown-menu {
-    position: inherit !important;
-    max-height: 40vh;
+    position: inherit !important;    
     overflow: scroll;
 }
 
@@ -1074,4 +1073,16 @@ textarea {
     margin-left: 20px;
     position: relative;
     top: 8px;
+}
+
+.jump-to-note-dialog .modal-body {
+    padding: 0 1rem;
+}
+
+.jump-to-note-results .aa-dropdown-menu {
+    max-height: 40vh;
+}
+
+.jump-to-note-results .aa-suggestions {
+    padding: 1rem 0;
 }


### PR DESCRIPTION
This is a proof-of-concept implementation in which the jump-to-note uses a list instead of a dropdown auto-completion. This approach seems to be used by most applications having a "Jump to..." functionality such as: VS Code, GNOME Builder, Obsidian.

It's achieved by tweaking some settings for the autocomplete library, including setting `debug` to avoid hiding the list when the input loses focus. 

All the other use-cases where note auto-completion is used should not be affected by this change.

@zadam , let me know your thoughts on this.

### Further improvements

I also propose the following:

* Consider removing the "X" button and show recents button near the input box since they don't provide much functionality in this case (the X button is equivalent to Ctrl+A followed by a backspace), whereas the recents are displayed now by default.
* Add a "No results" text instead of showing an empty list. VS Code displays a "No matching results" item whereas Obsidian allows the user to create a new note, similar to how Trilium does it on the new tab screen.
* Consider removing the "X" button near the modal. The input box looks slightly unbalanced because it was moved in the header. Not sure of the usefulness of the button since the dialog can be dismissed by clicking out of the modal or pressing Escape.

### Recording

[simplescreenrecorder-2023-08-26_17.54.59.webm](https://github.com/zadam/trilium/assets/21236836/46f49ba7-c0be-4657-82da-098d15a8af67)

### The "Jump to dialog" list in other applications:

VS code:

![image](https://github.com/zadam/trilium/assets/21236836/072c9327-758a-4e67-9a30-d6c29e78a238)

GNOME builder:

![image](https://github.com/zadam/trilium/assets/21236836/e5c079b5-f9f7-43a1-acf4-fe80c8644ae7)

Obsidian:

![image](https://github.com/zadam/trilium/assets/21236836/ad320f94-2eae-4325-a8b3-934399687506)
