### PR TITLE
Fix right click bookmark bug

### DIFF
--- a/src/public/app/widgets/buttons/launcher/note_launcher.js
+++ b/src/public/app/widgets/buttons/launcher/note_launcher.js
@@ -34,7 +34,7 @@ export default class NoteLauncher extends AbstractLauncher {
     async launch(evt) {
         // await because subclass overrides can be async
         const targetNoteId = await this.getTargetNoteId();
-        if (!targetNoteId) {
+        if (!targetNoteId || evt.which === 3) {
             return;
         }
 

--- a/src/public/app/widgets/buttons/open_note_button_widget.js
+++ b/src/public/app/widgets/buttons/open_note_button_widget.js
@@ -17,6 +17,9 @@ export default class OpenNoteButtonWidget extends OnClickButtonWidget {
     }
 
     async launch(evt) {
+        if (evt.which === 3) {
+            return;
+        }
         const ctrlKey = utils.isCtrlKey(evt);
 
         if ((evt.which === 1 && ctrlKey) || evt.which === 2) {


### PR DESCRIPTION
Right-click the bookmark note in the launch bar to call the right-click menu, but onAuxClick will be triggered and the note will be opened directly. This PR fixes the bug.