### PR TITLE
Add keyboard shortcuts for tabs

### DIFF
--- a/src/public/app/widgets/tab_row.js
+++ b/src/public/app/widgets/tab_row.js
@@ -267,7 +267,27 @@ export default class TabRowWidget extends BasicWidget {
                 }
             });
         });
+
+        keyboardActionService.setupActionsForElement('tabs', $(document), this);
     }
+
+    goToTab(tabNumber) {
+        const index = tabNumber === 0 ? this.tabEls.length - 1 : tabNumber - 1;
+        const tab = this.tabEls[index];
+        if (!tab) return;
+        appContext.tabManager.activateNoteContext(tab.getAttribute('data-ntx-id'));
+    }
+
+    firstTabCommand() {this.goToTab(1);}
+    secondTabCommand() {this.goToTab(2);}
+    thirdTabCommand() {this.goToTab(3);}
+    fourthTabCommand() {this.goToTab(4);}
+    fifthTabCommand() {this.goToTab(5);}
+    sixthTabCommand() {this.goToTab(6);}
+    seventhTabCommand() {this.goToTab(7);}
+    eigthTabCommand() {this.goToTab(8);}
+    ninthTabCommand() {this.goToTab(9);}
+    lastTabCommand() {this.goToTab(0);}
 
     setupStyle() {
         this.$style = $("<style>");

--- a/src/public/app/widgets/tab_row.js
+++ b/src/public/app/widgets/tab_row.js
@@ -268,11 +268,11 @@ export default class TabRowWidget extends BasicWidget {
             });
         });
 
-        keyboardActionService.setupActionsForElement('tabs', $(document), this);
+        keyboardActionService.setupActionsForElement('window', $(document), this);
     }
 
     goToTab(tabNumber) {
-        const index = tabNumber === 0 ? this.tabEls.length - 1 : tabNumber - 1;
+        const index = tabNumber === Number.POSITIVE_INFINITY ? this.tabEls.length - 1 : tabNumber - 1;
         const tab = this.tabEls[index];
         if (!tab) return;
         appContext.tabManager.activateNoteContext(tab.getAttribute('data-ntx-id'));
@@ -287,7 +287,7 @@ export default class TabRowWidget extends BasicWidget {
     seventhTabCommand() {this.goToTab(7);}
     eigthTabCommand() {this.goToTab(8);}
     ninthTabCommand() {this.goToTab(9);}
-    lastTabCommand() {this.goToTab(0);}
+    lastTabCommand() {this.goToTab(Number.POSITIVE_INFINITY);}
 
     setupStyle() {
         this.$style = $("<style>");

--- a/src/services/keyboard_actions.js
+++ b/src/services/keyboard_actions.js
@@ -231,6 +231,66 @@ const DEFAULT_KEYBOARD_ACTIONS = [
         description: "Open new empty window",
         scope: "window"
     },
+    {
+        actionName: "firstTab",
+        defaultShortcuts: ["CommandOrControl+1"],
+        description: "Activates the first tab in the list",
+        scope: "tabs"
+    },
+    {
+        actionName: "secondTab",
+        defaultShortcuts: ["CommandOrControl+2"],
+        description: "Activates the second tab in the list",
+        scope: "tabs"
+    },
+    {
+        actionName: "thirdTab",
+        defaultShortcuts: ["CommandOrControl+3"],
+        description: "Activates the third tab in the list",
+        scope: "tabs"
+    },
+    {
+        actionName: "fourthTab",
+        defaultShortcuts: ["CommandOrControl+4"],
+        description: "Activates the fourth tab in the list",
+        scope: "tabs"
+    },
+    {
+        actionName: "fifthTab",
+        defaultShortcuts: ["CommandOrControl+5"],
+        description: "Activates the fifth tab in the list",
+        scope: "tabs"
+    },
+    {
+        actionName: "sixthTab",
+        defaultShortcuts: ["CommandOrControl+6"],
+        description: "Activates the sixth tab in the list",
+        scope: "tabs"
+    },
+    {
+        actionName: "seventhTab",
+        defaultShortcuts: ["CommandOrControl+7"],
+        description: "Activates the seventh tab in the list",
+        scope: "tabs"
+    },
+    {
+        actionName: "eigthTab",
+        defaultShortcuts: ["CommandOrControl+8"],
+        description: "Activates the eigth tab in the list",
+        scope: "tabs"
+    },
+    {
+        actionName: "ninthTab",
+        defaultShortcuts: ["CommandOrControl+9"],
+        description: "Activates the ninth tab in the list",
+        scope: "tabs"
+    },
+    {
+        actionName: "lastTab",
+        defaultShortcuts: ["CommandOrControl+0"],
+        description: "Activates the last tab in the list",
+        scope: "tabs"
+    },
 
 
     {

--- a/src/services/keyboard_actions.js
+++ b/src/services/keyboard_actions.js
@@ -235,61 +235,61 @@ const DEFAULT_KEYBOARD_ACTIONS = [
         actionName: "firstTab",
         defaultShortcuts: ["CommandOrControl+1"],
         description: "Activates the first tab in the list",
-        scope: "tabs"
+        scope: "window"
     },
     {
         actionName: "secondTab",
         defaultShortcuts: ["CommandOrControl+2"],
         description: "Activates the second tab in the list",
-        scope: "tabs"
+        scope: "window"
     },
     {
         actionName: "thirdTab",
         defaultShortcuts: ["CommandOrControl+3"],
         description: "Activates the third tab in the list",
-        scope: "tabs"
+        scope: "window"
     },
     {
         actionName: "fourthTab",
         defaultShortcuts: ["CommandOrControl+4"],
         description: "Activates the fourth tab in the list",
-        scope: "tabs"
+        scope: "window"
     },
     {
         actionName: "fifthTab",
         defaultShortcuts: ["CommandOrControl+5"],
         description: "Activates the fifth tab in the list",
-        scope: "tabs"
+        scope: "window"
     },
     {
         actionName: "sixthTab",
         defaultShortcuts: ["CommandOrControl+6"],
         description: "Activates the sixth tab in the list",
-        scope: "tabs"
+        scope: "window"
     },
     {
         actionName: "seventhTab",
         defaultShortcuts: ["CommandOrControl+7"],
         description: "Activates the seventh tab in the list",
-        scope: "tabs"
+        scope: "window"
     },
     {
         actionName: "eigthTab",
         defaultShortcuts: ["CommandOrControl+8"],
         description: "Activates the eigth tab in the list",
-        scope: "tabs"
+        scope: "window"
     },
     {
         actionName: "ninthTab",
         defaultShortcuts: ["CommandOrControl+9"],
         description: "Activates the ninth tab in the list",
-        scope: "tabs"
+        scope: "window"
     },
     {
         actionName: "lastTab",
         defaultShortcuts: ["CommandOrControl+0"],
         description: "Activates the last tab in the list",
-        scope: "tabs"
+        scope: "window"
     },
 
 


### PR DESCRIPTION
Partially fixes #3735. I thought about implementing a separate menu where you can browse tabs, but I think that would better fit as part of the command palette whenever that happens.

Let me know if the implementation is alright.