### PR TITLE
Add new datePattern and monthPattern replacers

### DIFF
--- a/src/services/date_notes.js
+++ b/src/services/date_notes.js
@@ -29,6 +29,13 @@ function createNote(parentNote, noteTitle) {
     }).note;
 }
 
+function ordinal(n) {
+    var s = ["th", "st", "nd", "rd"],
+        v = n % 100;
+    return n + (s[(v - 20) % 10] || s[v] || s[0]);
+  }
+  
+
 /** @returns {BNote} */
 function getRootCalendarNote() {
     let rootNote;
@@ -145,6 +152,7 @@ function getDayNoteTitle(rootNote, dayNumber, dateObj) {
     const weekDay = DAYS[dateObj.getDay()];
 
     return pattern
+        .replace(/{ordinal}/g, ordinal(parseInt(dayNumber)))
         .replace(/{dayInMonthPadded}/g, dayNumber)
         .replace(/{isoDate}/g, dateUtils.utcDateStr(dateObj))
         .replace(/{weekDay}/g, weekDay)

--- a/src/services/date_notes.js
+++ b/src/services/date_notes.js
@@ -105,6 +105,8 @@ function getMonthNoteTitle(rootNote, monthNumber, dateObj) {
     const monthName = MONTHS[dateObj.getMonth()];
 
     return pattern
+        .replace(/{shortMonth3}/g, monthName.slice(0,3))
+        .replace(/{shortMonth4}/g, monthName.slice(0,4))
         .replace(/{monthNumberPadded}/g, monthNumber)
         .replace(/{month}/g, monthName);
 }


### PR DESCRIPTION
Added the following new `datePattern` and `monthPattern` replacers:

# `datePattern`
* `{ordinal}` is replaced with the ordinal date (e.g. 1st, 2nd, 3rd) etc.

# `monthPattern`
* `{shortMonth3}` is replaced with the first 3 letters of the month, e.g. Jan, Feb, etc.
* `{shortMonth4}` is replaced with the first 4 letters of the month, e.g. Sept, Octo, etc.

The docs will need to be updated.