### PR TITLE
Add hotkey option to toggle hide to tray

### DIFF
--- a/src/public/app/components/root_command_executor.js
+++ b/src/public/app/components/root_command_executor.js
@@ -6,6 +6,7 @@ import openService from "../services/open.js";
 import protectedSessionService from "../services/protected_session.js";
 import options from "../services/options.js";
 import froca from "../services/froca.js";
+import utils from "../services/utils.js";
 
 export default class RootCommandExecutor extends Component {
     editReadOnlyNoteCommand() {
@@ -153,6 +154,15 @@ export default class RootCommandExecutor extends Component {
                 }
             });
         }
+    }
+
+    toggleTrayCommand() {
+        if (!utils.isElectron()) return;
+        const {BrowserWindow} = utils.dynamicRequire('@electron/remote');
+        const windows = BrowserWindow.getAllWindows();
+        const isVisible = windows.every(w => w.isVisible());
+        const action = isVisible ? "hide" : "show"
+        for (const window of windows) window[action]();
     }
 
     firstTabCommand()   { this.#goToTab(1); }

--- a/src/services/keyboard_actions.js
+++ b/src/services/keyboard_actions.js
@@ -241,6 +241,12 @@ const DEFAULT_KEYBOARD_ACTIONS = [
         scope: "window"
     },
     {
+        actionName: "toggleTray",
+        defaultShortcuts: [],
+        description: "Shows/hides the application from the system tray",
+        scope: "window"
+    },
+    {
         actionName: "firstTab",
         defaultShortcuts: ["CommandOrControl+1"],
         description: "Activates the first tab in the list",


### PR DESCRIPTION
I decided not to set a default combo due to the potential for overlap with OS and other apps, personally I have been using `global:Ctrl+Alt+T` locally and it's been nice. This fixes #3043.

BTW: Now that I got my local development environment working properly for Trilium, I'm hoping to slowly tackle some more of the backlog once I feel more comfortable with the codebase.