### PR TITLE
Fixing css issue for Menu and search button

### DIFF
--- a/src/public/stylesheets/style.css
+++ b/src/public/stylesheets/style.css
@@ -311,7 +311,7 @@ button.btn, button.btn-sm {
 }
 
 #left-pane .btn:not(.btn-primary) {
-    background-color: var(--button-background-color);
+    background-color: var(--left-pane-background-color);
     color: var(--left-pane-text-color);
 }
 
@@ -933,8 +933,9 @@ body {
     width: 100%;
 }
 
-#launcher-pane .icon-action:hover {
-    background-color: var(--hover-item-background-color);
+#launcher-pane .icon-action {
+    background-color: var(--launcher-pane-background-color);
+    color: var(--launcher-pane-text-color);
 }
 
 #left-pane {


### PR DESCRIPTION
Menu button and css button show different color if button background is different that launcher/left pane background
![Screenshot from 2023-12-10 12-45-32](https://github.com/zadam/trilium/assets/5411581/fb67f8f7-f3de-46fd-9cbd-6f820c11dfc8)

```css
@font-face {
  font-family: 'Raleway';
  font-style: normal;
  font-weight: 400;
  src: url('/custom/fonts/raleway.woff2') format('woff2');
}

:root {
    --main-font-family: 'Raleway' !important;
    --main-font-size: normal;
    --tree-font-family: inherit;
    --tree-font-size: normal;
    --detail-font-family: inherit;
    --detail-font-size: normal;
    --detail-text-font-family: 'Garamond' !important;

    --main-background-color: #404552;
    --main-text-color: #AFB8C6;
    --main-border-color: #AFB8C6;
    --accented-background-color: #383C4A;
    --more-accented-background-color: #2F343F;
    --header-background-color: #383C4A;
    --button-background-color: #2F343F;
    --button-disabled-background-color: #404552;
    --button-border-color: #333;
    --button-text-color: #AFB8C6;
    --button-border-radius: 2px;
    --primary-button-background-color: #6c757d;
    --primary-button-text-color: white;
    --primary-button-border-color: #6c757d;
    --muted-text-color: #86919F;
    --input-text-color: #AFB8C6;
    --input-background-color: #404552;
    --hover-item-text-color: white;
    --hover-item-background-color: #4877B1;
    --active-item-text-color: white;
    --active-item-background-color: #4877B1;
    --menu-text-color: #AFB8C6;
    --menu-background-color: #383C4A;
    --tooltip-background-color: #383C4A;
    --link-color: lightskyblue;
    --modal-background-color: #404552;
    --modal-backdrop-color: black;
    --scrollbar-border-color: rgba(175, 184, 198, 0.5);
    --left-pane-background-color: #DDD
}

body .note-detail-text {
    font-size: 120%;
}

body .CodeMirror {
    filter: invert(100%) hue-rotate(180deg);
}

``` 