### PR TITLE
sort children during export to ensure a more stable format

### DIFF
--- a/src/services/export/zip.js
+++ b/src/services/export/zip.js
@@ -181,6 +181,8 @@ async function exportToZip(taskContext, branch, format, res, setHeaders = true) 
 
         noteIdToMeta[note.noteId] = meta;
 
+        // sort children for having a stable / reproducible export format
+        note.sortChildren();
         const childBranches = note.getChildBranches()
             .filter(branch => branch.noteId !== '_hidden');
 


### PR DESCRIPTION
Hello,

I'm using a script to run a daily markdown export and commit the result to git for backup and to use git tools to browse history.

I'm using notes with clones and noticed that the export format is not stable. For instance, with two notes clones NoteA and NoteB, export on one day may produce NoteA.md + NoteB.clone.md and another day NoteA.clone.md + NoteB.md. This makes it harder to track history.

Looking at the code, I see that this may happen since the notes tree traversal doesn't sort the children by their `notePosition` attribute. This PR calls `sortChildren` to produce a more stable and reproducible export.