### PR TITLE
Add the -o option to the groupmod command used in start-docker.sh

### DIFF
--- a/start-docker.sh
+++ b/start-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 [[ ! -z "${USER_UID}" ]] && usermod -u ${USER_UID} node || echo "No USER_UID specified, leaving 1000"
-[[ ! -z "${USER_GID}" ]] && groupmod -g ${USER_GID} node || echo "No USER_GID specified, leaving 1000"
+[[ ! -z "${USER_GID}" ]] && groupmod -og ${USER_GID} node || echo "No USER_GID specified, leaving 1000"
 
 chown -R node:node /home/node
 exec su-exec node node ./src/www


### PR DESCRIPTION
This matters when USER_GID is set to an existing group (e.g. you want node to run in the users (gid 100) group). This fixes #4631