### PR TITLE
Fix ribbon tooltips getting stuck on the screen by setting a small delay before saving attributes in attributeeditor

### DIFF
--- a/src/public/app/widgets/attribute_widgets/attribute_editor.js
+++ b/src/public/app/widgets/attribute_widgets/attribute_editor.js
@@ -200,7 +200,7 @@ export default class AttributeEditorWidget extends NoteContextAwareWidget {
             this.attributeDetailWidget.hide();
         });
 
-        this.$editor.on('blur', () => this.save());
+        this.$editor.on('blur', () => setTimeout(() => this.save(), 100)); // Timeout to fix https://github.com/zadam/trilium/issues/4160
 
         this.$addNewAttributeButton = this.$widget.find('.add-new-attribute-button');
         this.$addNewAttributeButton.on('click', e => this.addNewAttribute(e));


### PR DESCRIPTION
It appears that if the save method is executed concurrently with Bootstrap's hide tooltip method, the tooltip will become detached from its parent and become trapped on the screen. The exact reason for this conflict is unknown.

It is really not a pleasant user experience to have tooltips stuck on the screen with no way to remove them other than to restart the application. I suggest applying this simple fix since it appears to have no negative impact when the save function is delayed. For the time being, I believe this is the lesser of two evils, but perhaps more time should be spent in the future investigating the root cause.

Fixes #4160 