### PR TITLE
Reduce warnings count caused by bin/copy-trilium.sh

### DIFF
--- a/bin/build-linux-x64.sh
+++ b/bin/build-linux-x64.sh
@@ -2,49 +2,37 @@
 
 SRC_DIR=./dist/trilium-linux-x64-src
 
-if [ "$1" != "DONTCOPY" ]
-then
-    ./bin/copy-trilium.sh $SRC_DIR
-fi
+[ "$1" != "DONTCOPY" ] && ./bin/copy-trilium.sh "$SRC_DIR"
 
-rm -r $SRC_DIR/src/public/app-dist/*.mobile.*
+rm -r "$SRC_DIR"/src/public/app-dist/*.mobile.*
 
 echo "Copying required linux-x64 binaries"
-
-cp -r bin/better-sqlite3/linux-desktop-better_sqlite3.node $SRC_DIR/node_modules/better-sqlite3/build/Release/better_sqlite3.node
+cp -r bin/better-sqlite3/linux-desktop-better_sqlite3.node "$SRC_DIR"/node_modules/better-sqlite3/build/Release/better_sqlite3.node
 
 echo "Packaging linux x64 electron build"
-
-./node_modules/.bin/electron-packager $SRC_DIR --asar --out=dist --executable-name=trilium --platform=linux --arch=x64 --overwrite
+./node_modules/.bin/electron-packager "$SRC_DIR" --asar --out=dist --executable-name=trilium --platform=linux --arch=x64 --overwrite
 
 BUILD_DIR=./dist/trilium-linux-x64
-rm -rf $BUILD_DIR
+rm -rf "$BUILD_DIR"
 
-mv "./dist/Trilium Notes-linux-x64" $BUILD_DIR
+mv "./dist/Trilium Notes-linux-x64" "$BUILD_DIR"
 
-cp images/app-icons/png/128x128.png $BUILD_DIR/icon.png
+cp images/app-icons/png/128x128.png "$BUILD_DIR"/icon.png
+cp bin/tpl/anonymize-database.sql "$BUILD_DIR"/
 
-cp bin/tpl/anonymize-database.sql $BUILD_DIR/
+cp -r dump-db "$BUILD_DIR"/
+rm -rf "$BUILD_DIR"/dump-db/node_modules
 
-cp -r dump-db $BUILD_DIR/
-rm -rf $BUILD_DIR/dump-db/node_modules
-
-cp bin/tpl/trilium-portable.sh $BUILD_DIR/
-chmod 755 $BUILD_DIR/trilium-portable.sh
-
-cp bin/tpl/trilium-safe-mode.sh $BUILD_DIR/
-chmod 755 $BUILD_DIR/trilium-safe-mode.sh
-
-cp bin/tpl/trilium-no-cert-check.sh $BUILD_DIR/
-chmod 755 $BUILD_DIR/trilium-no-cert-check.sh
+for f in 'trilium-portable' 'trilium-safe-mode' 'trilium-no-cert-check'; do
+    cp bin/tpl/"$f".sh "$BUILD_DIR"/
+    chmod 755 "$BUILD_DIR"/"$f".sh
+done
 
 echo "Packaging linux x64 electron distribution..."
 VERSION=`jq -r ".version" package.json`
 
-cd dist
-
-tar cJf trilium-linux-x64-${VERSION}.tar.xz trilium-linux-x64
-
-cd ..
+pushd dist
+    tar cJf "trilium-linux-x64-${VERSION}.tar.xz" trilium-linux-x64
+popd
 
 bin/build-debian.sh

--- a/bin/copy-trilium.sh
+++ b/bin/copy-trilium.sh
@@ -7,44 +7,42 @@ fi
 
 n exec 18.18.2 npm run webpack
 
-DIR=$1
+DIR="$1"
 
-rm -rf $DIR
-mkdir $DIR
+rm -rf "$DIR"
+mkdir -v "$DIR"
 
 echo "Copying Trilium to build directory $DIR"
 
-cp -r images $DIR/
-cp -r libraries $DIR/
-cp -r src $DIR/
-cp -r db $DIR/
-cp -r package.json $DIR/
-cp -r package-lock.json $DIR/
-cp -r README.md $DIR/
-cp -r LICENSE $DIR/
-cp -r config-sample.ini $DIR/
-cp -r electron.js $DIR/
-cp webpack-* $DIR/
+for d in 'images' 'libraries' 'src' 'db'; do
+    cp -r "$d" "$DIR"/
+done
+for f in 'package.json' 'package-lock.json' 'README.md' 'LICENSE' 'config-sample.ini' 'electron.js'; do
+    cp "$f" "$DIR"/
+done
+cp webpack-* "$DIR"/      # here warning because there is no 'webpack-*', but webpack.config.js only
 
 # run in subshell (so we return to original dir)
 (cd $DIR && n exec 18.18.2 npm install --only=prod)
 
+if [[ -d "$DIR"/node_modules ]]; then
 # cleanup of useless files in dependencies
-rm -r $DIR/node_modules/image-q/demo
-rm -r $DIR/node_modules/better-sqlite3/Release
-rm -r $DIR/node_modules/better-sqlite3/deps/sqlite3.tar.gz
-rm -r $DIR/node_modules/@jimp/plugin-print/fonts
-rm -r $DIR/node_modules/jimp/browser
-rm -r $DIR/node_modules/jimp/fonts
+    for d in 'image-q/demo' 'better-sqlite3/Release' 'better-sqlite3/deps/sqlite3.tar.gz' '@jimp/plugin-print/fonts' 'jimp/browser' 'jimp/fonts'; do
+        [[ -e "$DIR"/node_modules/"$d" ]] && rm -rv "$DIR"/node_modules/"$d"
+    done
 
 # delete all tests (there are often large images as test file for jimp etc.)
-find $DIR/node_modules -name test -exec rm -rf {} \;
-find $DIR/node_modules -name docs -exec rm -rf {} \;
-find $DIR/node_modules -name demo -exec rm -rf {} \;
+    for d in 'test' 'docs' 'demo'; do
+        find "$DIR"/node_modules -name "$d" -exec rm -rf {} \;
+    done
+fi
 
 find $DIR/libraries -name "*.map" -type f -delete
 
-cp $DIR/src/public/app/share.js $DIR/src/public/app-dist/
-cp -r $DIR/src/public/app/doc_notes $DIR/src/public/app-dist/
+d="$DIR"/src/public
+[[ -d "$d"/app-dist ]] || mkdir -pv "$d"/app-dist
+cp -v "$d"/app/share.js "$d"/app-dist/
+cp -rv "$d"/app/doc_notes "$d"/app-dist/
 
-rm -rf $DIR/src/public/app
+rm -rf "$d"/app
+unset f d DIR

--- a/bin/copy-trilium.sh
+++ b/bin/copy-trilium.sh
@@ -4,13 +4,17 @@ if [[ $# -eq 0 ]] ; then
     echo "Missing argument of target directory"
     exit 1
 fi
+if ! [[ $(which npm) ]]; then
+    echo "Missing npm"
+    exit 1
+fi
 
-n exec 18.18.2 npm run webpack
+n exec 18.18.2 npm run webpack || npm run webpack
 
 DIR="$1"
 
 rm -rf "$DIR"
-mkdir -v "$DIR"
+mkdir -pv "$DIR"
 
 echo "Copying Trilium to build directory $DIR"
 
@@ -41,8 +45,8 @@ find $DIR/libraries -name "*.map" -type f -delete
 
 d="$DIR"/src/public
 [[ -d "$d"/app-dist ]] || mkdir -pv "$d"/app-dist
-cp -v "$d"/app/share.js "$d"/app-dist/
-cp -rv "$d"/app/doc_notes "$d"/app-dist/
+cp "$d"/app/share.js "$d"/app-dist/
+cp -r "$d"/app/doc_notes "$d"/app-dist/
 
 rm -rf "$d"/app
 unset f d DIR


### PR DESCRIPTION
alexei@Aspire:~/build/trilium-0.62.4$ ./bin/build-linux-x64.sh 
./bin/copy-trilium.sh: line 8: n: command not found
Copying Trilium to build directory ./dist/trilium-linux-x64-src
cp: unable to execute stat for 'webpack-*': there is no such file or catalog
./bin/copy-trilium.sh: line 30: n: command not found
rm: unable to remove './dist/trilium-linux-x64-src/node_modules/image-q/demo': there is no such file or catalog
rm: unable to remove './dist/trilium-linux-x64-src/node_modules/better-sqlite3/Release': there is no such file or catalog
rm: unable to remove './dist/trilium-linux-x64-src/node_modules/better-sqlite3/deps/sqlite3.tar.gz': there is no such file or catalog
rm: unable to remove './dist/trilium-linux-x64-src/node_modules/@jimp/plugin-print/fonts': there is no such file or catalog
rm: unable to remove './dist/trilium-linux-x64-src/node_modules/jimp/browser': there is no such file or catalog
rm: unable to remove './dist/trilium-linux-x64-src/node_modules/jimp/fonts': there is no such file or catalog
find: ‘./dist/trilium-linux-x64-src/node_modules’: there is no such file or catalog
find: ‘./dist/trilium-linux-x64-src/node_modules’: there is no such file or catalog
find: ‘./dist/trilium-linux-x64-src/node_modules’: there is no such file or catalog
cp: Unable to create regular file './dist/trilium-linux-x64-src/src/public/app-dist/': it is not a catalog
rm: unable to remove './dist/trilium-linux-x64-src/src/public/app-dist/*.mobile.*': there is no such file or catalog
Copying required linux-x64 binaries
cp: Unable to create regular file './dist/trilium-linux-x64-src/node_modules/better-sqlite3/build/Release/better_sqlite3.node': there is no such file or catalog
Packaging linux x64 electron build
...
...